### PR TITLE
Change all functions to export two functions for scalars and arrays

### DIFF
--- a/src/psychrometrics/index.js
+++ b/src/psychrometrics/index.js
@@ -1,8 +1,17 @@
 import { p_sat } from "./p_sat";
-import { p_sat_torr } from "./p_sat_torr";
-import { t_o } from "./t_o";
+import { p_sat_torr, p_sat_torr_array } from "./p_sat_torr";
+import { t_o, t_o_array } from "./t_o";
 import { enthalpy } from "./enthalpy";
 import { t_wb } from "./t_wb";
 import { t_dp } from "./t_dp";
 
-export default { p_sat, p_sat_torr, t_o, enthalpy, t_wb, t_dp };
+export default {
+  p_sat,
+  p_sat_torr,
+  p_sat_torr_array,
+  t_o,
+  t_o_array,
+  enthalpy,
+  t_wb,
+  t_dp,
+};

--- a/src/psychrometrics/p_sat_torr.js
+++ b/src/psychrometrics/p_sat_torr.js
@@ -1,9 +1,23 @@
 /**
+ * @public
  * Estimates the saturation vapour pressure in [torr].
+ * @see {@link p_sat_torr_array} for a version that supports arrays
  *
  * @param {number} tdb  - dry bulb air temperature [C]
  * @returns {number} saturation vapour pressure [torr]
  */
 export function p_sat_torr(tdb) {
   return Math.exp(18.6686 - 4030.183 / (tdb + 235.0));
+}
+
+/**
+ * @public
+ * Estimates the saturation vapour pressure in [torr].
+ * @see {@link p_sat_torr} for a version that supports scalar arguments
+ *
+ * @param {number[]} tdb  - dry bulb air temperature [C]
+ * @returns {number[]} saturation vapour pressure [torr]
+ */
+export function p_sat_torr_array(tdb) {
+  return tdb.map(p_sat_torr);
 }

--- a/src/psychrometrics/t_o.js
+++ b/src/psychrometrics/t_o.js
@@ -25,7 +25,7 @@ export function t_o(tdb, tr, v, standard = "ISO") {
 
 /**
  * Calculates operative temperature in accordance with ISO 7726:1998.
- * Accepts array arguments. @see {@link t_o} for scalar arguments
+ * @see {@link t_o} for a version that supports scalar arguments
  *
  * @param {number[]} tdb - air temperature [C]
  * @param {number[]} tr - mean radiant temperature [C]

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,7 +1,9 @@
 import {
   body_surface_area,
   v_relative,
+  v_relative_array,
   clo_dynamic,
+  clo_dynamic_array,
   units_converter,
   running_mean_outdoor_temperature,
   f_svv,
@@ -10,7 +12,9 @@ import {
 export default {
   body_surface_area,
   v_relative,
+  v_relative_array,
   clo_dynamic,
+  clo_dynamic_array,
   units_converter,
   running_mean_outdoor_temperature,
   f_svv,

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -330,18 +330,31 @@ export function body_surface_area(weight, height, formula = "dubois") {
  * space plus the relative air speed caused by the body movement. Vag is assumed
  * to be 0 for metabolic rates equal and lower than 1 met and otherwise equal to
  * Vag = 0.3 (M - 1) (m/s)
+ * @see {@link v_relative_array} for a version that supports array arguments
  *
- * @template {(number | number[])} T
- * @param {T} v - air spped measured by the sensor, [m/s]
+ * @param {number} v - air spped measured by the sensor, [m/s]
  * @param {number} met - metabolic rate, [met]
- * @returns {T} relative air speed, [m/s]
+ * @returns {number} relative air speed, [m/s]
  */
 export function v_relative(v, met) {
   if (met <= 1) return v;
-  if (Array.isArray(v)) {
-    return v.map((_v) => _v_relative_single(_v, met));
-  }
   return _v_relative_single(v, met);
+}
+
+/**
+ * Estimates the relative air speed which combines the average air speed of the
+ * space plus the relative air speed caused by the body movement. Vag is assumed
+ * to be 0 for metabolic rates equal and lower than 1 met and otherwise equal to
+ * Vag = 0.3 (M - 1) (m/s)
+ * @see {@link v_relative} for a version that supports scalar arguments
+ *
+ * @param {number[]} v - air spped measured by the sensor, [m/s]
+ * @param {number} met - metabolic rate, [met]
+ * @returns {number[]} relative air speed, [m/s]
+ */
+export function v_relative_array(v, met) {
+  if (met <= 1) return v;
+  return v.map((_v) => _v_relative_single(_v, met));
 }
 
 /**
@@ -361,34 +374,46 @@ function _v_relative_single(v, met) {
  * of the body movement for met equal or higher than 1.2 met using the equation
  * clo = Icl × (0.6 + 0.4/met)
  *
- * @template {(number | number[])} T
- * @param {T} clo - clothing insulation, [clo]
- * @param {T} met - metabolic rate, [met]
+ * @param {number} clo - clothing insulation, [clo]
+ * @param {number} met - metabolic rate, [met]
  * @param {("ASHRAE" | "ISO")} [standard="ASHRAE"] - If "ASHRAE", uses Equation provided in Section 5.2.2.2 of ASHRAE 55 2020
- * @returns {T} dunamic clothing insulation, [clo]
+ * @returns {number} dunamic clothing insulation, [clo]
  */
 export function clo_dynamic(clo, met, standard = "ASHRAE") {
   if (standard !== "ASHRAE" && standard !== "ISO")
     throw new Error(
       "only the ISO 7730 and ASHRAE 55 2020 models have been implemented",
     );
-  if (Array.isArray(clo) !== Array.isArray(met))
-    throw new Error("clo and met should both be arrays or numbers");
-
-  if (Array.isArray(clo)) {
-    if (standard === "ASHRAE")
-      return met.map((_met, index) =>
-        _met > 1.2 ? _clo_dynamic_single(clo[index], _met) : clo[index],
-      );
-    if (standard === "ISO")
-      return met.map((_met, index) =>
-        _met > 1 ? _clo_dynamic_single(clo[index], _met) : clo[index],
-      );
-  }
-
   if ((standard === "ASHRAE" && met <= 1.2) || (standard === "ISO" && met <= 1))
     return clo;
   return _clo_dynamic_single(clo, met);
+}
+
+/**
+ * Estimates the dynamic clothing insulation of a moving occupant. The activity as
+ * well as the air speed modify the insulation characteristics of the clothing and the
+ * adjacent air layer. Consequently, the ISO 7730 states that the clothing insulation
+ * shall be corrected [2]_. The ASHRAE 55 Standard corrects for the effect
+ * of the body movement for met equal or higher than 1.2 met using the equation
+ * clo = Icl × (0.6 + 0.4/met)
+ *
+ * @param {number[]} clo - clothing insulation, [clo]
+ * @param {number[]} met - metabolic rate, [met]
+ * @param {("ASHRAE" | "ISO")} [standard="ASHRAE"] - If "ASHRAE", uses Equation provided in Section 5.2.2.2 of ASHRAE 55 2020
+ * @returns {number[]} dunamic clothing insulation, [clo]
+ */
+export function clo_dynamic_array(clo, met, standard = "ASHRAE") {
+  if (standard === "ASHRAE")
+    return met.map((_met, index) =>
+      _met > 1.2 ? _clo_dynamic_single(clo[index], _met) : clo[index],
+    );
+  if (standard === "ISO")
+    return met.map((_met, index) =>
+      _met > 1 ? _clo_dynamic_single(clo[index], _met) : clo[index],
+    );
+  throw new Error(
+    "only the ISO 7730 and ASHRAE 55 2020 models have been implemented",
+  );
 }
 
 /**

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -373,6 +373,7 @@ function _v_relative_single(v, met) {
  * shall be corrected [2]_. The ASHRAE 55 Standard corrects for the effect
  * of the body movement for met equal or higher than 1.2 met using the equation
  * clo = Icl × (0.6 + 0.4/met)
+ * @see {@link clo_dynamic_array} for a version that supports array arguments
  *
  * @param {number} clo - clothing insulation, [clo]
  * @param {number} met - metabolic rate, [met]
@@ -396,6 +397,7 @@ export function clo_dynamic(clo, met, standard = "ASHRAE") {
  * shall be corrected [2]_. The ASHRAE 55 Standard corrects for the effect
  * of the body movement for met equal or higher than 1.2 met using the equation
  * clo = Icl × (0.6 + 0.4/met)
+ * @see {@link clo_dynamic} for a version that supports scalar arguments
  *
  * @param {number[]} clo - clothing insulation, [clo]
  * @param {number[]} met - metabolic rate, [met]

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -38,8 +38,16 @@ describe("NPM Package", () => {
     expect(jsthermalcomfort.utilities).toHaveProperty("v_relative");
   });
 
+  it("should have utilities.v_relative_array", () => {
+    expect(jsthermalcomfort.utilities).toHaveProperty("v_relative_array");
+  });
+
   it("should have utilities.clo_dynamic", () => {
     expect(jsthermalcomfort.utilities).toHaveProperty("clo_dynamic");
+  });
+
+  it("should have utilities.clo_dynamic_array", () => {
+    expect(jsthermalcomfort.utilities).toHaveProperty("clo_dynamic_array");
   });
 
   it("should have utilities.units_converter", () => {
@@ -64,7 +72,15 @@ describe("NPM Package", () => {
     expect(jsthermalcomfort.psychrometrics).toHaveProperty("p_sat_torr");
   });
 
+  it("should have psychrometrics.p_sat_torr_array", () => {
+    expect(jsthermalcomfort.psychrometrics).toHaveProperty("p_sat_torr_array");
+  });
+
   it("should have psychrometrics.t_o", () => {
+    expect(jsthermalcomfort.psychrometrics).toHaveProperty("t_o");
+  });
+
+  it("should have psychrometrics.t_o_array", () => {
     expect(jsthermalcomfort.psychrometrics).toHaveProperty("t_o");
   });
 

--- a/tests/psychrometrics/p_sat_torr.test.js
+++ b/tests/psychrometrics/p_sat_torr.test.js
@@ -1,5 +1,9 @@
 import { expect, describe, it } from "@jest/globals";
-import { p_sat_torr } from "../../src/psychrometrics/p_sat_torr.js";
+import {
+  p_sat_torr,
+  p_sat_torr_array,
+} from "../../src/psychrometrics/p_sat_torr.js";
+import { deep_close_to_array } from "../test_utilities.js";
 
 describe("p_sat_torr", () => {
   it.each([
@@ -16,6 +20,21 @@ describe("p_sat_torr", () => {
     ({ tdb, expected }) => {
       const result = p_sat_torr(tdb);
       expect(result).toBeCloseTo(expected);
+    },
+  );
+});
+
+describe("p_sat_torr_array", () => {
+  it.each([
+    {
+      tdb: [0, 1, -1, -273.15],
+      expected: [4.5671, 4.911372, 4.2443798, 9.699125053317317e53],
+    },
+  ])(
+    "returns $expected when dryBulbAirTemp is $dryBulbAirTemp",
+    ({ tdb, expected }) => {
+      const result = p_sat_torr_array(tdb);
+      deep_close_to_array(result, expected, 2);
     },
   );
 });


### PR DESCRIPTION
- Only the functions that support both in the Python version will have both versions in this library