### PR TITLE
Yuchen/two nodes changes requested federico

### DIFF
--- a/src/models/two_nodes.js
+++ b/src/models/two_nodes.js
@@ -872,6 +872,9 @@ function calculate_two_nodes(
     eMax =
       (Math.exp(18.6686 - 4030.183 / (tSkin + 235.0)) - vaporPressure) /
       (rEa + rEcl);
+    if (eMax == 0) {
+      eMax = 0.001;
+    }
     const pRsw = eRsw / eMax;
     w = 0.06 + 0.94 * pRsw;
     eDiff = w * eMax - eRsw;

--- a/src/models/two_nodes.js
+++ b/src/models/two_nodes.js
@@ -82,7 +82,7 @@ import { p_sat_torr } from "../psychrometrics/p_sat_torr.js";
  * @param {number} [body_surface_area=1.8258] Body surface area, default value 1.8258 [m2] in [ft2] if units = ‘IP’
  * @param {number} [p_atmospheric=101325] Atmospheric pressure, default value 101325 [Pa] in [atm] if units = ‘IP’
  * @param {"standing" | "sitting"} [body_position="standing"] Select either “sitting” or “standing”
- * @param {number} [max_skin_blood_flow=80] Maximum blood flow from the core to the skin, [kg/h/m2] default 80
+ * @param {number} [max_skin_blood_flow=90] Maximum blood flow from the core to the skin, [kg/h/m2] default 90
  * @param {TwoNodesKwargs} [kwargs]
  *
  * @returns {TwoNodesReturnType} object with results of two_nodes
@@ -122,7 +122,7 @@ export function two_nodes(
   body_surface_area = 1.8258,
   p_atmospheric = 101325,
   body_position = "standing",
-  max_skin_blood_flow = 80,
+  max_skin_blood_flow = 90,
   kwargs = {},
 ) {
   const defaults_kwargs = {
@@ -288,13 +288,13 @@ const skinBloodFlowNeutral = 6.3;
  * @param {number[]} bodySurfaceArray Body surface area, default value 1.8258 [m2] in [ft2] if units = ‘IP’
  * @param {number[]} pAtmArray Atmospheric pressure, default value 101325 [Pa] in [atm] if units = ‘IP’
  * @param {"standing" | "sitting"} bodyPositionArray Select either “sitting” or “standing”
- * @param {number[]} maxSkinBloodFlowArray Maximum blood flow from the core to the skin, [kg/h/m2] default 80
+ * @param {number[]} maxSkinBloodFlowArray Maximum blood flow from the core to the skin, [kg/h/m2] default 90
  * @param {TwoNodesKwargs} [kwargs]
  *
  * @returns {TwoNodesArrayReturnType} object with results of two_nodes_array
  *
  * @example
- * const results = two_nodes_array([25,30], [25,35], [0.3,0.5], [50,60], [1.2,1.5], [0.5, 0.3], [0], [1.8258], [101325], ["standing"], [90])
+ * const results = two_nodes_array([25,30], [25,35], [0.3,0.5], [50,60], [1.2,1.5], [0.5, 0.3], [0,0], [1.8258,1.8258], [101325,101325], ["standing","standing"], [90,90])
  * console.log(results); // {
   e_skin: [ 16.2, 60.4 ],
   e_rsw: [ 7, 51.9 ],
@@ -360,7 +360,7 @@ export function two_nodes_array(
   }
 
   if (maxSkinBloodFlowArray === undefined) {
-    maxSkinBloodFlowArray = tdbArray.map((_) => 80);
+    maxSkinBloodFlowArray = tdbArray.map((_) => 90);
   }
 
   if (joint_kwargs.calculate_ce) {
@@ -727,7 +727,7 @@ function calculate_percent_satisfied(tOp, v) {
  * @param {number} bodySurfaceArea Body surface area, default value 1.8258 [m2] in [ft2] if units = ‘IP’
  * @param {number} pAtmospheric Atmospheric pressure, default value 101325 [Pa] in [atm] if units = ‘IP’
  * @param {"standing" | "sitting"} bodyPosition Select either “sitting” or “standing”
- * @param {number} maxSkinBloodFlow Maximum blood flow from the core to the skin, [kg/h/m2] default 80
+ * @param {number} maxSkinBloodFlow Maximum blood flow from the core to the skin, [kg/h/m2] default 90
  * @param {TwoNodesKwargs} [kwargs]
  *
  */

--- a/tests/models/set_tmp.test.js
+++ b/tests/models/set_tmp.test.js
@@ -102,7 +102,7 @@ describe("set_tmp", () => {
       units: "SI",
       limit_inputs: false,
       kwargs: { round: false },
-      expected: 66.34040551491287,
+      expected: 66.25029829890893,
     },
     {
       tdb: 77,
@@ -118,7 +118,7 @@ describe("set_tmp", () => {
       units: "SI",
       limit_inputs: false,
       kwargs: { round: false },
-      expected: 66.38956921560549,
+      expected: 66.29853487495205,
     },
     {
       tdb: 5,
@@ -303,7 +303,7 @@ describe("set_tmp_array", () => {
       bodyPositionArray: undefined,
       units: "SI",
       limit_inputs: false,
-      expected: [66.4, 48.8],
+      expected: [66.3, 48.8],
     },
     {
       tdbArray: [77, 50, 40],
@@ -318,7 +318,7 @@ describe("set_tmp_array", () => {
       bodyPositionArray: undefined,
       units: "SI",
       limit_inputs: false,
-      expected: [66.4, 48.8, 35.7],
+      expected: [66.3, 48.8, 35.7],
     },
     {
       tdbArray: [77, 50, 40],


### PR DESCRIPTION
According to Federico, the conversion should be aligned with the Python code rather than the documentation. So the value of max_skin_blood_flow is updated to 90, and the corresponding tests that are impacted by this change in "set_tmp" are also updated. 
This PR also includes the minor change in "two_nodes_optimized" made by Federico on his PR on the Python version: https://github.com/CenterForTheBuiltEnvironment/pythermalcomfort/pull/68/files 