### PR TITLE
NPM publish on GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Publish Package to NPM
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org/"
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsthermalcomfort",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "A JavaScript package to calculate thermal comfort indices (e.g., Predicted Mean Vote, Standard Effective Temperature, Predicted Heat Strain).",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "jsthermalcomfort",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A JavaScript package to calculate thermal comfort indices (e.g., Predicted Mean Vote, Standard Effective Temperature, Predicted Heat Strain).",
-  "types": "./dist/index.d.ts",
   "type": "module",
   "files": [
     "lib"


### PR DESCRIPTION
- @FedericoTartarini This requires the repository to have a secret called `NPM_TOKEN` with the NPM token.
- This PR will make it so that when we create a release using the GitHub release system, it will also trigger a publish to NPM. (I like this pattern since it means that we will see all the releases in the repository for quick access, and they will be synced with NPM releases.)
- Bumping the version to `0.1.0`