### PR TITLE
Refactored tests 

### DIFF
--- a/lib/cjs/types/models/cooling_effect.d.ts
+++ b/lib/cjs/types/models/cooling_effect.d.ts
@@ -1,4 +1,9 @@
 /**
+ * @typedef {object} CoolingEffectResult
+ * @property {number} ce - Cooling Effect, default in [°C] in [°F] if `units` = 'IP'
+ * @public
+ */
+/**
  * Returns the value of the Cooling Effect ( {@link https://en.wikipedia.org/wiki/Thermal_comfort#Cooling_Effect|CE} )
  * calculated in compliance with the ASHRAE 55 2020 Standard {@link #ref_1|[1]}.
  * The {@link https://en.wikipedia.org/wiki/Thermal_comfort#Cooling_Effect|CE} of the elevated air speed
@@ -34,16 +39,22 @@
  *
  * @param {number} [wme=0] - external work
  * @param {'SI'|'IP'} [units= "SI"] - select the SI (International System of Units) or the IP (Imperial Units) system.
- * @returns {number} ce - Cooling Effect, default in [°C] in [°F] if `units` = 'IP'
+ * @returns {CoolingEffectResult} ce - Cooling Effect, default in [°C] in [°F] if `units` = 'IP'
  *
  * @example
  * const CE = cooling_effect(25, 25, 0.3, 50, 1.2, 0.5);
- * console.log(CE); // Output: 1.64
+ * console.log(CE); // Output: {ce: 1.64}
  *
  * // For users who want to use the IP system
  * const CE_IP = cooling_effect(77, 77, 1.64, 50, 1, 0.6, "IP");
- * console.log(CE_IP); // Output: 3.74
+ * console.log(CE_IP); // Output: {ce: 3.74}
  */
-export function cooling_effect(tdb: number, tr: number, vr: number, rh: number, met: number, clo: number, wme?: number, units?: 'SI' | 'IP'): number;
+export function cooling_effect(tdb: number, tr: number, vr: number, rh: number, met: number, clo: number, wme?: number, units?: 'SI' | 'IP'): CoolingEffectResult;
 export function brent(f: any, lowerBound: any, upperBound: any, tolerance?: number, maxIterations?: number): any;
+export type CoolingEffectResult = {
+    /**
+     * - Cooling Effect, default in [°C] in [°F] if `units` = 'IP'
+     */
+    ce: number;
+};
 //# sourceMappingURL=cooling_effect.d.ts.map

--- a/lib/cjs/types/models/e_pmv.d.ts
+++ b/lib/cjs/types/models/e_pmv.d.ts
@@ -1,4 +1,10 @@
 /**
+ * @typedef {Object} EPmvResult
+ * @property {number} e_pmv - Predicted Mean Vote
+ * @public
+ */
+
+/**
  * @typedef {Object} E_pmvKwargs
  * @property {'SI'|'IP'} units - select the SI (International System of Units) or the IP (Imperial Units) system.
  * @property { boolean } limit_inputs - Default is True. By default, if the inputs are outside the standard
@@ -9,6 +15,9 @@
  *    0 < vr [m/s] < 1, 0.8 < met [met] < 4, 0 < clo [clo] < 2, and -2 < PMV < 2.
  * @public
  */
+
+import { EPmvResult } from "../../../../src/models/e_pmv";
+
 /**
  * Returns Adjusted Predicted Mean Votes with Expectancy Factor (ePMV). This index was developed by
  * Fanger, P. O. et al. (2002). In non-air-conditioned buildings in warm climates, occupants may sense
@@ -47,7 +56,7 @@
  * @param {number} [wme=0] - External work
  * @param {E_pmvKwargs} [kwargs] - additional arguments
  *
- * @returns {number} pmv - Predicted Mean Vote
+ * @returns {EPmvResult} set containing results for the model
  *
  * @example
  * const tdb = 28;
@@ -62,9 +71,9 @@
  * const e_coefficient = 0.6;
  *
  * const result = e_pmv(tdb, tr, v_r, rh, met, clo_d, e_coefficient);
- * console.log(result) // output 0.51
+ * console.log(result) // output {e_pmv: 0.51}
  */
-export function e_pmv(tdb: number, tr: number, vr: number, rh: number, met: number, clo: number, e_coefficient: number, wme?: number, kwargs?: E_pmvKwargs): number;
+export function e_pmv(tdb: number, tr: number, vr: number, rh: number, met: number, clo: number, e_coefficient: number, wme?: number, kwargs?: E_pmvKwargs): EPmvResult;
 /**
  * Returns Adjusted Predicted Mean Votes with Expectancy Factor (ePMV). This index was developed by
  * Fanger, P. O. et al. (2002). In non-air-conditioned buildings in warm climates, occupants may sense

--- a/lib/cjs/types/models/heat_index.d.ts
+++ b/lib/cjs/types/models/heat_index.d.ts
@@ -1,4 +1,12 @@
 /**
+ * @typedef {object} HeatIndexResult
+ * @property {number} hi - Heat Index, default in [°C] in [°F] if `units` = 'IP'.
+ * @public
+ */
+
+import { HeatIndexResult } from "../../../../src/models/heat_index";
+
+/**
  * Calculates the Heat Index (HI). It combines air temperature and relative humidity to determine an apparent temperature.
  * The HI equation {@link #ref_12|[12]} is derived by multiple regression analysis in temperature and relative humidity from the first version
  * of Steadman’s (1979) apparent temperature (AT) {@link #ref_13|[13]}.
@@ -13,7 +21,7 @@
  * @param {boolean} [options.round=true] - If True rounds output value, if False it does not round it.
  * @param {"SI" | "IP"} [options.units="SI"] - Select the SI (International System of Units) or the IP (Imperial Units) system.
  *
- * @returns {number} Heat Index, default in [°C] in [°F] if `units` = 'IP'.
+ * @returns {HeatIndexResult} set containing results for the model
  *
  * @example
  * const hi = heat_index(25, 50); // returns 25.9
@@ -23,5 +31,5 @@
 export function heat_index(tdb: number, rh: number, options?: {
     round?: boolean;
     units?: "SI" | "IP";
-}): number;
+}): HeatIndexResult;
 //# sourceMappingURL=heat_index.d.ts.map

--- a/lib/cjs/types/models/net.d.ts
+++ b/lib/cjs/types/models/net.d.ts
@@ -1,4 +1,10 @@
 /**
+ * @typedef {object} NetResult
+ * @property {number} net - Normal Effective Temperature, [°C]
+ * @public
+ */
+
+/**
  * Calculates the Normal Effective Temperature (NET). Missenard (1933)
  * devised a formula for calculating effective temperature. The index
  * establishes a link between the same condition of the organism's
@@ -27,13 +33,13 @@
  * @param {boolean} [options.round = true] - If true, rounds output value. If
  * false, it does not.
  *
- * @returns {number} Normal Effective Temperature, [°C]
+ * @returns {NetResult} set containing results for the
  *
  * @example
  * const result = net(37, 100, 0.1);
- * console.log(result); // -> 37
+ * console.log(result); // -> {net: 37}
  */
 export function net(tdb: number, rh: number, v: number, options?: {
     round?: boolean;
-}): number;
+}): NetResult;
 //# sourceMappingURL=net.d.ts.map

--- a/lib/cjs/types/models/pet_steady.d.ts
+++ b/lib/cjs/types/models/pet_steady.d.ts
@@ -1,4 +1,12 @@
 /**
+ * @typedef {object} PetSteadyResult
+ * @property {number} pet - Steady-state PET under the given ambient conditions
+ * @public
+ */
+
+import { PetSteadyResult } from "../../../../src/models/pet_steady";
+
+/**
  * The steady physiological equivalent temperature (PET) is calculated using the Munich
  * Energy-balance Model for Individuals (MEMI), which simulates the human body's thermal
  * circumstances in a medically realistic manner. PET is defined as the air temperature
@@ -37,15 +45,15 @@
  * @param {number} [height=1.8] - height, [m]
  * @param {number} [wme=0] - external work, [W/(m2)]
  *
- * @returns {number} Steady-state PET under the given ambient conditions
+ * @returns {PetSteadyResult} set containing results for the model
  *
  * @example
  * const result = pet_steady(20, 20, 50, 0.15, 1.37, 0.5);
- * console.log(result); // 18.85
+ * console.log(result); // {pet: 18.85}
  */
-export function pet_steady(tdb: number, tr: number, v: number, rh: number, met: number, clo: number, p_atm?: number, position?: 1 | 2 | 3, age?: number, sex?: 1 | 2, weight?: number, height?: number, wme?: number): number;
-export type NewtonRaphsonFunction = (: [number, number, number]) => [number, number, number];
-export type NewtonRaphsonSingleFunction = (: [number]) => [number];
+export function pet_steady(tdb: number, tr: number, v: number, rh: number, met: number, clo: number, p_atm?: number, position?: 1 | 2 | 3, age?: number, sex?: 1 | 2, weight?: number, height?: number, wme?: number): PetSteadyResult;
+export type NewtonRaphsonFunction = (t: [number, number, number]) => [number, number, number];
+export type NewtonRaphsonSingleFunction = (t: [number]) => [number];
 export type VasomotricitytRet = {
     /**
      * - Blood flow rate, [kg/m2/h]

--- a/lib/cjs/types/models/solar_gain.d.ts
+++ b/lib/cjs/types/models/solar_gain.d.ts
@@ -43,17 +43,17 @@
  * clothing or skin color of the occupants is available.
  * Note: Short-wave absorptivity typically ranges from 0.57 to 0.84, depending
  * on skin and clothing color. More information is available in Blum (1945).
- * @param {"standing" | "supine" | "seated"} [posture="seated"] - Default 'seated' list of available options 'standing', 'supine' or 'seated'
+ * @param {"standing" | "supine" | "sitting"} [posture="sitting"] - Default 'sitting' list of available options 'standing', 'supine' or 'sitting'
  * @param {number} [floor_reflectance=0.7] - Floor refectance. It is assumed to be constant and equal to 0.6.
  *
  * @returns {SolarGainReturnType}
  *
  * @example
  * import {solar_gain} from "jsthermalcomfort/models";
- * const results = solar_gain(0, 120, 800, 0.5, 0.7, "seated");
+ * const results = solar_gain(0, 120, 800, 0.5, 0.7, "sitting");
  * console.log(results); // {erf: 42.9, delta_mrt: 10.3}
  */
-export function solar_gain(sol_altitude: number, sharp: number, sol_radiation_dir: number, sol_transmittance: number, f_svv: number, f_bes: number, asw?: number, posture?: "standing" | "supine" | "seated", floor_reflectance?: number): SolarGainReturnType;
+export function solar_gain(sol_altitude: number, sharp: number, sol_radiation_dir: number, sol_transmittance: number, f_svv: number, f_bes: number, asw?: number, posture?: "standing" | "supine" | "sitting", floor_reflectance?: number): SolarGainReturnType;
 /**
  *
  * @param {number[]} arr

--- a/lib/cjs/types/models/vertical_tmp_grad_ppd.d.ts
+++ b/lib/cjs/types/models/vertical_tmp_grad_ppd.d.ts
@@ -1,7 +1,7 @@
 /**
  * @typedef {Object} VerTmpGradReturnType - a result set containing the predicted precentage of dissatisfied and the acceptability
- * @property {number} PPD_vg Predicted Percentage of Dissatisfied occupants with vertical temperature gradient, [%]
- * @property {boolean} Acceptability The ASHRAE 55 2020 standard defines that the value of air speed at the ankle level
+ * @property {number} ppd_vg Predicted Percentage of Dissatisfied occupants with vertical temperature gradient, [%]
+ * @property {boolean} acceptability The ASHRAE 55 2020 standard defines that the value of air speed at the ankle level
  * is acceptable if PPD_ad is lower or equal than 5 %
  * @public
  */
@@ -38,7 +38,7 @@
  * @returns {VerTmpGradReturnType} Object with results of the PPD with vertical temprature gradient.
  *
  * @example
- * const result = vertical_tmp_grad_ppd(25, 25, 0.1, 50, 1.2, 0.5, 7); // returns {'PPD_vg': 12.6, 'Acceptability': false}
+ * const result = vertical_tmp_grad_ppd(25, 25, 0.1, 50, 1.2, 0.5, 7); // returns {'ppd_vg': 12.6, 'acceptability': false}
  */
 export function vertical_tmp_grad_ppd(tdb: number, tr: number, vr: number, rh: number, met: number, clo: number, vertical_tmp_grad: number, units?: "SI" | "IP"): VerTmpGradReturnType;
 /**

--- a/lib/cjs/types/models/wbgt.d.ts
+++ b/lib/cjs/types/models/wbgt.d.ts
@@ -1,4 +1,10 @@
 /**
+ * @typedef {object} WbgtResult
+ * @property {number} wbgt - Wet Bulb Globe Temperature Index, [°C]
+ * @public
+ */
+
+/**
  * Calculates the Wet Bulb Globe Temperature (WBGT) index calculated in
  * compliance with the ISO 7243 {@link #ref_11|[11]}. The WBGT is a heat stress index that
  * measures the thermal environment to which a person is exposed. In most
@@ -33,19 +39,19 @@
  * exposed to direct solar radiation. If this is set to true without also
  * setting `options.tdb` then an error will be thrown.
  *
- * @returns {number} Wet Bulb Globe Temperature Index, [°C]
+ * @returns {WbgtResult} set containing results for the model
  *
  * @example
  * const result = wbgt(25, 32);
- * console.log(result); // -> 27.1
+ * console.log(result); // -> {"wbgt": 27.1}
  *
  * @example
  * const result = wbgt(25, 32, { tdb: 20, with_solar_radiation: true });
- * console.log(result); // -> 25.9
+ * console.log(result); // -> {"wbgt": 25.9}
  */
 export function wbgt(twb: number, tg: number, options?: {
     round?: boolean;
     tdb?: number;
     with_solar_load?: boolean;
-}): number;
+}): WbgtResult;
 //# sourceMappingURL=wbgt.d.ts.map

--- a/src/models/cooling_effect.js
+++ b/src/models/cooling_effect.js
@@ -92,7 +92,7 @@ export function cooling_effect(
       round: false,
       calculate_ce: true,
     },
-  );
+  ).set;
 
   function func(x) {
     return (
@@ -113,7 +113,7 @@ export function cooling_effect(
           round: false,
           calculate_ce: true,
         },
-      ) - initial_set_tmp
+      ).set - initial_set_tmp
     );
   }
 

--- a/src/models/cooling_effect.js
+++ b/src/models/cooling_effect.js
@@ -1,6 +1,11 @@
-import { units_converter, round } from "../utilities/utilities.js";
+import { round, units_converter } from "../utilities/utilities.js";
 import { set_tmp } from "./set_tmp.js";
 
+/**
+ * @typedef {object} CoolingEffectResult
+ * @property {number} ce - Cooling Effect, default in [°C] in [°F] if `units` = 'IP'
+ * @public
+ */
 /**
  * Returns the value of the Cooling Effect ( {@link https://en.wikipedia.org/wiki/Thermal_comfort#Cooling_Effect|CE} )
  * calculated in compliance with the ASHRAE 55 2020 Standard {@link #ref_1|[1]}.
@@ -37,15 +42,15 @@ import { set_tmp } from "./set_tmp.js";
  *
  * @param {number} [wme=0] - external work
  * @param {'SI'|'IP'} [units= "SI"] - select the SI (International System of Units) or the IP (Imperial Units) system.
- * @returns {number} ce - Cooling Effect, default in [°C] in [°F] if `units` = 'IP'
+ * @returns {CoolingEffectResult} ce - Cooling Effect, default in [°C] in [°F] if `units` = 'IP'
  *
  * @example
  * const CE = cooling_effect(25, 25, 0.3, 50, 1.2, 0.5);
- * console.log(CE); // Output: 1.64
+ * console.log(CE); // Output: {ce: 1.64}
  *
  * // For users who want to use the IP system
  * const CE_IP = cooling_effect(77, 77, 1.64, 50, 1, 0.6, "IP");
- * console.log(CE_IP); // Output: 3.74
+ * console.log(CE_IP); // Output: {ce: 3.74}
  */
 export function cooling_effect(
   tdb,
@@ -65,7 +70,7 @@ export function cooling_effect(
   }
 
   if (vr <= 0.1) {
-    return 0;
+    return { ce: 0 };
   }
 
   const still_air_threshold = 0.1;
@@ -130,7 +135,9 @@ export function cooling_effect(
     ce = (ce / 1.8) * 3.28;
   }
 
-  return round(ce, 2);
+  ce = round(ce, 2);
+
+  return { ce: ce };
 }
 
 // https://gist.github.com/ryanspradlin/18c1010b7dd2d875284933d018c5c908

--- a/src/models/e_pmv.js
+++ b/src/models/e_pmv.js
@@ -1,5 +1,11 @@
-import { pmv, pmv_array } from "./pmv.js";
 import { round } from "../utilities/utilities.js";
+import { pmv, pmv_array } from "./pmv.js";
+
+/**
+ * @typedef {Object} EPmvResult
+ * @property {number} e_pmv - Predicted Mean Vote
+ * @public
+ */
 
 /**
  * @typedef {Object} E_pmvKwargs
@@ -51,7 +57,7 @@ import { round } from "../utilities/utilities.js";
  * @param {number} [wme=0] - External work
  * @param {E_pmvKwargs} [kwargs] - additional arguments
  *
- * @returns {number} pmv - Predicted Mean Vote
+ * @returns {EPmvResult} set containing results for the model
  *
  * @example
  * const tdb = 28;
@@ -66,7 +72,7 @@ import { round } from "../utilities/utilities.js";
  * const e_coefficient = 0.6;
  *
  * const result = e_pmv(tdb, tr, v_r, rh, met, clo_d, e_coefficient);
- * console.log(result) // output 0.51
+ * console.log(result) // output {e_pmv: 0.51}
  */
 export function e_pmv(
   tdb,
@@ -89,8 +95,9 @@ export function e_pmv(
 
   met = _pmv > 0 ? met * (1 + _pmv * -0.067) : met;
   _pmv = pmv(tdb, tr, vr, rh, met, clo, wme, "ISO", kwargs);
+  _pmv = round(_pmv * e_coefficient, 2);
 
-  return round(_pmv * e_coefficient, 2);
+  return { e_pmv: _pmv };
 }
 
 /**

--- a/src/models/heat_index.js
+++ b/src/models/heat_index.js
@@ -1,6 +1,11 @@
 import { round } from "../utilities/utilities.js";
 
 /**
+ * @typedef {object} HeatIndexResult
+ * @property {number} hi - Heat Index, default in [°C] in [°F] if `units` = 'IP'.
+ * @public
+ */
+/**
  * Calculates the Heat Index (HI). It combines air temperature and relative humidity to determine an apparent temperature.
  * The HI equation {@link #ref_12|[12]} is derived by multiple regression analysis in temperature and relative humidity from the first version
  * of Steadman’s (1979) apparent temperature (AT) {@link #ref_13|[13]}.
@@ -15,17 +20,14 @@ import { round } from "../utilities/utilities.js";
  * @param {boolean} [options.round=true] - If True rounds output value, if False it does not round it.
  * @param {"SI" | "IP"} [options.units="SI"] - Select the SI (International System of Units) or the IP (Imperial Units) system.
  *
- * @returns {number} Heat Index, default in [°C] in [°F] if `units` = 'IP'.
+ * @returns {HeatIndexResult} set containing results for the model
  *
  * @example
- * const hi = heat_index(25, 50); // returns 25.9
+ * const hi = heat_index(25, 50); // returns {hi: 25.9}
  *
  * @category Thermophysiological models
  */
 export function heat_index(tdb, rh, options = { round: true, units: "SI" }) {
-  /**
-   * @type {number}
-   */
   let hi;
   let tdb_squared = Math.pow(tdb, 2);
   let rh_squared = Math.pow(rh, 2);
@@ -54,5 +56,7 @@ export function heat_index(tdb, rh, options = { round: true, units: "SI" }) {
       0.00000199 * tdb_squared * rh_squared;
   }
 
-  return options.round === undefined || options.round ? round(hi, 1) : hi;
+  hi = options.round === undefined || options.round ? round(hi, 1) : hi;
+
+  return { hi: hi };
 }

--- a/src/models/net.js
+++ b/src/models/net.js
@@ -1,4 +1,9 @@
 import { round } from "../utilities/utilities.js";
+/**
+ * @typedef {object} NetResult
+ * @property {number} net - Normal Effective Temperature, [°C]
+ * @public
+ */
 
 /**
  * Calculates the Normal Effective Temperature (NET). Missenard (1933)
@@ -29,22 +34,22 @@ import { round } from "../utilities/utilities.js";
  * @param {boolean} [options.round = true] - If true, rounds output value. If
  * false, it does not.
  *
- * @returns {number} Normal Effective Temperature, [°C]
+ * @returns {NetResult} set containing results for the
  *
  * @example
  * const result = net(37, 100, 0.1);
- * console.log(result); // -> 37
+ * console.log(result); // -> {net: 37}
  */
 export function net(tdb, rh, v, options = { round: true }) {
   const frac = 1.0 / (1.76 + 1.4 * v ** 0.75);
-  const et =
+  let et =
     37 -
     (37 - tdb) / (0.68 - 0.0014 * rh + frac) -
     0.29 * tdb * (1 - 0.01 * rh);
 
   if (options.round) {
-    return round(et, 1);
+    et = round(et, 1);
   }
 
-  return et;
+  return { net: et };
 }

--- a/src/models/pet_steady.js
+++ b/src/models/pet_steady.js
@@ -1,6 +1,11 @@
-import { body_surface_area } from "../utilities/utilities.js";
 import { p_sat } from "../psychrometrics/p_sat.js";
-import { round } from "../utilities/utilities.js";
+import { body_surface_area, round } from "../utilities/utilities.js";
+
+/**
+ * @typedef {object} PetSteadyResult
+ * @property {number} pet - Steady-state PET under the given ambient conditions
+ * @public
+ */
 
 /**
  * The steady physiological equivalent temperature (PET) is calculated using the Munich
@@ -41,11 +46,11 @@ import { round } from "../utilities/utilities.js";
  * @param {number} [height=1.8] - height, [m]
  * @param {number} [wme=0] - external work, [W/(m2)]
  *
- * @returns {number} Steady-state PET under the given ambient conditions
+ * @returns {PetSteadyResult} set containing results for the model
  *
  * @example
  * const result = pet_steady(20, 20, 50, 0.15, 1.37, 0.5);
- * console.log(result); // 18.85
+ * console.log(result); // {pet: 18.85}
  */
 export function pet_steady(
   tdb,
@@ -89,7 +94,7 @@ export function pet_steady(
       ),
     t_guess,
   );
-  return pet_fc(t_stable);
+  return { pet: pet_fc(t_stable) };
 }
 
 /**

--- a/src/models/pmv_ppd.js
+++ b/src/models/pmv_ppd.js
@@ -335,6 +335,7 @@ export function pmv_ppd_array(
       //if v_r is higher than 0.1 follow methodology ASHRAE Appendix H, H3
       return vrValue > 0.1
         ? cooling_effect(tdb[i], tr[i], vrValue, rh[i], met[i], clo[i], wme[i])
+            .ce
         : 0;
     });
   }

--- a/src/models/pmv_ppd.js
+++ b/src/models/pmv_ppd.js
@@ -129,7 +129,7 @@ export function pmv_ppd(
   };
   kwargs = Object.assign(default_kwargs, kwargs);
 
-  if (kwargs.units && kwargs.units === "IP") {
+  if (kwargs.units && kwargs.units.toUpperCase() === "IP") {
     // Conversion from IP to SI units
     ({ tdb, tr, vr } = units_converter({ tdb, tr, vr }, "IP"));
   }
@@ -154,11 +154,10 @@ export function pmv_ppd(
     clo: [clo],
     airspeed_control: kwargs.airspeed_control,
   });
-
   let ce = 0;
   if (standard === "ASHRAE") {
     //if v_r is higher than 0.1 follow methodology ASHRAE Appendix H, H3
-    ce = vr > 0.1 ? cooling_effect(tdb, tr, vr, rh, met, clo, wme) : 0;
+    ce = vr > 0.1 ? cooling_effect(tdb, tr, vr, rh, met, clo, wme).ce : 0;
   }
 
   tdb = tdb - ce;

--- a/src/models/set_tmp.js
+++ b/src/models/set_tmp.js
@@ -1,10 +1,16 @@
+import { roundArray, two_nodes, two_nodes_array } from "../models/two_nodes.js";
 import {
-  units_converter,
-  units_converter_array,
   check_standard_compliance_array,
   round,
+  units_converter,
+  units_converter_array,
 } from "../utilities/utilities.js";
-import { two_nodes, two_nodes_array, roundArray } from "../models/two_nodes.js";
+
+/**
+ * @typedef {Object} SetTmpResult
+ * @property {number} set - Standard effective temperature in array, [°C]
+ * @public
+ */
 
 /**
  * @typedef {Object} SetTmpKwargs - a keywords argument set containing the additional arguments for Standard Effective Temperature calculation
@@ -45,10 +51,10 @@ import { two_nodes, two_nodes_array, roundArray } from "../models/two_nodes.js";
  * @param {"SI" | "IP"} [units="SI"] Select the SI (International System of Units) or the IP (Imperial Units) system.
  * @param {boolean} [limit_inputs=true] By default, if the inputs are outsude the following limits the function returns nan. If False returns values regardless of the input values.
  * @param {SetTmpKwargs} [kwargs]
- * @returns {number} SET – Standard effective temperature in array, [°C]
+ * @returns {SetTmpResult} set containing results for the model
  *
  * @example
- * const set = set_tmp(25, 25, 0.1, 50, 1.2, 0.5); // returns 24.3
+ * const set = set_tmp(25, 25, 0.1, 50, 1.2, 0.5); // returns {set: 24.3}
  */
 export function set_tmp(
   tdb,
@@ -140,9 +146,9 @@ export function set_tmp(
   }
 
   if (joint_kwargs.round) {
-    return round(set_tmp, 1);
+    set_tmp = round(set_tmp, 1);
   }
-  return set_tmp;
+  return { set: set_tmp };
 }
 
 /**

--- a/src/models/solar_gain.js
+++ b/src/models/solar_gain.js
@@ -1,12 +1,11 @@
-import { round } from "../utilities/utilities.js";
-import { transpose_sharp_altitude } from "../utilities/utilities.js";
+import { round, transpose_sharp_altitude } from "../utilities/utilities.js";
 
 // avoid reallocating these arrays accross function calls
 const _alt_range = [0, 15, 30, 45, 60, 75, 90];
 const _az_range = [0, 15, 30, 45, 60, 75, 90, 105, 120, 135, 150, 165, 180];
 
 // avoid reallocating these table across function calls
-const _fp_table_seated = [
+const _fp_table_sitting = [
   [0.29, 0.324, 0.305, 0.303, 0.262, 0.224, 0.177],
   [0.292, 0.328, 0.294, 0.288, 0.268, 0.227, 0.177],
   [0.288, 0.332, 0.298, 0.29, 0.264, 0.222, 0.177],
@@ -84,14 +83,14 @@ const _fp_table = [
  * clothing or skin color of the occupants is available.
  * Note: Short-wave absorptivity typically ranges from 0.57 to 0.84, depending
  * on skin and clothing color. More information is available in Blum (1945).
- * @param {"standing" | "supine" | "seated"} [posture="seated"] - Default 'seated' list of available options 'standing', 'supine' or 'seated'
+ * @param {"standing" | "supine" | "sitting"} [posture="sitting"] - Default 'sitting' list of available options 'standing', 'supine' or 'sitting'
  * @param {number} [floor_reflectance=0.7] - Floor refectance. It is assumed to be constant and equal to 0.6.
  *
  * @returns {SolarGainReturnType}
  *
  * @example
  * import {solar_gain} from "jsthermalcomfort/models";
- * const results = solar_gain(0, 120, 800, 0.5, 0.7, "seated");
+ * const results = solar_gain(0, 120, 800, 0.5, 0.7, "sitting");
  * console.log(results); // {erf: 42.9, delta_mrt: 10.3}
  */
 export function solar_gain(
@@ -102,19 +101,19 @@ export function solar_gain(
   f_svv,
   f_bes,
   asw = 0.7,
-  posture = "seated",
+  posture = "sitting",
   floor_reflectance = 0.6,
 ) {
   posture = posture.toLowerCase();
-  if (posture !== "standing" && posture !== "supine" && posture !== "seated")
-    throw new Error("Posture has to be either standing, supine or seated");
+  if (posture !== "standing" && posture !== "supine" && posture !== "sitting")
+    throw new Error("Posture has to be either standing, supine or sitting");
 
   const deg_to_rad = 0.0174532925;
   const hr = 6;
   const i_diff = 0.2 * sol_radiation_dir;
 
   // fp is the projected area factor
-  const fp_table = posture === "seated" ? _fp_table_seated : _fp_table;
+  const fp_table = posture === "sitting" ? _fp_table_sitting : _fp_table;
 
   if (posture === "supine") {
     [sharp, sol_altitude] = transpose_sharp_altitude(sharp, sol_altitude);
@@ -136,7 +135,7 @@ export function solar_gain(
   fp += fp22 * (sharp - az1) * (sol_altitude - alt1);
   fp /= (az2 - az1) * (alt2 - alt1);
 
-  const f_eff = posture === "seated" ? 0.696 : 0.725; // fraction of the body surface exposed to environmental radiation
+  const f_eff = posture === "sitting" ? 0.696 : 0.725; // fraction of the body surface exposed to environmental radiation
 
   const sw_abs = asw;
   const lw_abs = 0.95;

--- a/src/models/utci.js
+++ b/src/models/utci.js
@@ -1,8 +1,8 @@
 import {
-  units_converter,
-  valid_range,
   round,
+  units_converter,
   units_converter_array,
+  valid_range,
 } from "../utilities/utilities.js";
 
 const g = [
@@ -122,7 +122,7 @@ export function utci(
       stress_category: mapping(utci_approx),
     };
   }
-  return utci_approx;
+  return { utci: utci_approx };
 }
 
 /**

--- a/src/models/vertical_tmp_grad_ppd.js
+++ b/src/models/vertical_tmp_grad_ppd.js
@@ -1,14 +1,14 @@
+import { pmv } from "../models/pmv.js";
 import {
-  round,
   check_standard_compliance,
+  round,
   units_converter,
 } from "../utilities/utilities.js";
-import { pmv } from "../models/pmv.js";
 
 /**
  * @typedef {Object} VerTmpGradReturnType - a result set containing the predicted precentage of dissatisfied and the acceptability
- * @property {number} PPD_vg Predicted Percentage of Dissatisfied occupants with vertical temperature gradient, [%]
- * @property {boolean} Acceptability The ASHRAE 55 2020 standard defines that the value of air speed at the ankle level
+ * @property {number} ppd_vg Predicted Percentage of Dissatisfied occupants with vertical temperature gradient, [%]
+ * @property {boolean} acceptability The ASHRAE 55 2020 standard defines that the value of air speed at the ankle level
  * is acceptable if PPD_ad is lower or equal than 5 %
  * @public
  */
@@ -46,7 +46,7 @@ import { pmv } from "../models/pmv.js";
  * @returns {VerTmpGradReturnType} Object with results of the PPD with vertical temprature gradient.
  *
  * @example
- * const result = vertical_tmp_grad_ppd(25, 25, 0.1, 50, 1.2, 0.5, 7); // returns {'PPD_vg': 12.6, 'Acceptability': false}
+ * const result = vertical_tmp_grad_ppd(25, 25, 0.1, 50, 1.2, 0.5, 7); // returns {'ppd_vg': 12.6, 'acceptability': false}
  */
 export function vertical_tmp_grad_ppd(
   tdb,
@@ -82,8 +82,8 @@ export function vertical_tmp_grad_ppd(
   const acceptability = check_acceptability(ppd_vg);
 
   return {
-    PPD_vg: ppd_vg,
-    Acceptability: acceptability,
+    ppd_vg: ppd_vg,
+    acceptability: acceptability,
   };
 }
 

--- a/src/models/wbgt.js
+++ b/src/models/wbgt.js
@@ -7,6 +7,12 @@ const optionDefaults = {
 };
 
 /**
+ * @typedef {object} WbgtResult
+ * @property {number} wbgt - Wet Bulb Globe Temperature Index, [°C]
+ * @public
+ */
+
+/**
  * Calculates the Wet Bulb Globe Temperature (WBGT) index calculated in
  * compliance with the ISO 7243 {@link #ref_11|[11]}. The WBGT is a heat stress index that
  * measures the thermal environment to which a person is exposed. In most
@@ -41,15 +47,15 @@ const optionDefaults = {
  * exposed to direct solar radiation. If this is set to true without also
  * setting `options.tdb` then an error will be thrown.
  *
- * @returns {number} Wet Bulb Globe Temperature Index, [°C]
+ * @returns {WbgtResult} set containing results for the model
  *
  * @example
  * const result = wbgt(25, 32);
- * console.log(result); // -> 27.1
+ * console.log(result); // -> {"wbgt": 27.1}
  *
  * @example
  * const result = wbgt(25, 32, { tdb: 20, with_solar_radiation: true });
- * console.log(result); // -> 25.9
+ * console.log(result); // -> {"wbgt": 25.9}
  */
 export function wbgt(twb, tg, options) {
   const opt = Object.assign({}, optionDefaults, options);
@@ -70,5 +76,5 @@ export function wbgt(twb, tg, options) {
     return round(t_wbg, 1);
   }
 
-  return t_wbg;
+  return { wbgt: t_wbg };
 }

--- a/tests/models/comftest.js
+++ b/tests/models/comftest.js
@@ -24,7 +24,7 @@ export const testDataUrls = {
   verticalTmpGradPpd: prefixURL + "ts_vertical_tmp_grad_ppd.json",
   wc: prefixURL + "ts_wind_chill.json",
   wbgt: prefixURL + "ts_wbgt.json",
-  twoNodes: prefixURL + "ts_two_nodes.json",
+  twoNodes: prefixURL + "ts_two_nodes_gagge.json",
   solarGain: prefixURL + "ts_solar_gain.json",
   setTmp: prefixURL + "ts_set.json",
 };

--- a/tests/models/cooling_effect.test.js
+++ b/tests/models/cooling_effect.test.js
@@ -1,53 +1,22 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
+import { describe } from "@jest/globals";
 import { cooling_effect } from "../../src/models/cooling_effect";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import utility functions
+import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
 
-// Variables to store data fetched from remote source
-let testData;
-let tolerance;
+let returnArray = false;
 
-// Fetch data before running tests
-beforeAll(async () => {
-  ({ testData, tolerance } = await loadTestData(
-    testDataUrls.coolingEffect,
-    "ce",
-  ));
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.coolingEffect,
+  returnArray,
+);
 
 describe("cooling_effect", () => {
-  it("should run tests after data is loaded", () => {
-    if (!testData || !testData.data) {
-      throw new Error("Test data is undefined or data not loaded");
-    }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, tr, vr, rh, met, clo, wme, units } = inputs;
+    const modelResult = cooling_effect(tdb, tr, vr, rh, met, clo, wme, units);
 
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Skip test cases with array inputs using utility function
-      if (shouldSkipTest(inputs) || outputs.ce === undefined) {
-        return;
-      }
-
-      const { tdb, tr, vr, rh, met, clo, units } = inputs;
-      const result = cooling_effect(
-        tdb,
-        tr,
-        vr,
-        rh,
-        met,
-        clo,
-        undefined,
-        units,
-      );
-
-      // Compare the result and ensure values are close
-      if (result === 0 && outputs.ce !== 0) {
-        console.warn(
-          `Assuming cooling effect = 0 since it could not be calculated for this set of inputs tdb=${tdb}, tr=${tr}, rh=${rh}, vr=${vr}, clo=${clo}, met=${met}`,
-        );
-        expect(result).toBe(0);
-      } else {
-        expect(result).toBeCloseTo(outputs.ce, tolerance);
-      }
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/discomfort_index.test.js
+++ b/tests/models/discomfort_index.test.js
@@ -1,34 +1,22 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import shared utilities
+import { describe } from "@jest/globals";
 import { discomfort_index } from "../../src/models/discomfort_index";
 import { testDataUrls } from "./comftest";
+import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
 
-let testData;
-let tolerance;
+let returnArray = false;
 
-beforeAll(async () => {
-  const result = await loadTestData(
-    testDataUrls.discomfortIndex,
-    "discomfort_index",
-  ); // Use the correct tolerance key
-  testData = result.testData;
-  tolerance = result.tolerance;
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.discomfortIndex,
+  returnArray,
+);
 
 describe("discomfort_index", () => {
-  it("should run tests after data is loaded and skip data with arrays", () => {
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Skip data that contains arrays
-      if (shouldSkipTest(inputs) || outputs === undefined) {
-        return;
-      }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, rh } = inputs;
+    const modelResult = discomfort_index(tdb, rh);
 
-      const { tdb, rh } = inputs;
-      const result = discomfort_index(tdb, rh);
-
-      // Compare results
-      expect(result.di).toBeCloseTo(outputs.di, tolerance);
-      expect(result.discomfort_condition).toBe(outputs.discomfort_condition);
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/e_pmv.test.js
+++ b/tests/models/e_pmv.test.js
@@ -1,34 +1,22 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import shared utilities
+import { describe, test } from "@jest/globals";
 import { e_pmv } from "../../src/models/e_pmv";
 import { testDataUrls } from "./comftest";
+import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
 
-let testData;
-let tolerance;
+let returnArray = false;
 
-beforeAll(async () => {
-  const result = await loadTestData(testDataUrls.ePmv, "pmv"); // Use the correct tolerance key
-  testData = result.testData;
-  tolerance = result.tolerance;
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.ePmv,
+  returnArray,
+);
 
 describe("e_pmv", () => {
-  it("should run tests after data is loaded and skip data with arrays", () => {
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Skip data that contains arrays
-      if (
-        shouldSkipTest(inputs) ||
-        outputs === undefined ||
-        outputs.pmv === undefined
-      ) {
-        return;
-      }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, tr, vr, rh, met, clo, e_coefficient } = inputs;
+    const modelResult = e_pmv(tdb, tr, vr, rh, met, clo, e_coefficient);
 
-      const { tdb, tr, vr, rh, met, clo, e_coefficient } = inputs;
-      const result = e_pmv(tdb, tr, vr, rh, met, clo, e_coefficient);
-
-      // Compare results
-      expect(result).toBeCloseTo(outputs.pmv, tolerance);
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/heat_index.test.js
+++ b/tests/models/heat_index.test.js
@@ -1,36 +1,22 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import shared utilities
+import { describe, test } from "@jest/globals";
 import { heat_index } from "../../src/models/heat_index";
 import { testDataUrls } from "./comftest";
+import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
 
-let testData;
-let tolerance;
+let returnArray = false;
 
-beforeAll(async () => {
-  const result = await loadTestData(testDataUrls.heatIndex, "hi"); // Use the correct tolerance key
-  testData = result.testData;
-  tolerance = result.tolerance || 0.1; // Set default tolerance to 0.1
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.heatIndex,
+  returnArray,
+);
 
 describe("heat_index", () => {
-  it("should run tests after data is loaded and skip data with arrays", () => {
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Skip data that contains arrays
-      if (
-        shouldSkipTest(inputs) ||
-        outputs === undefined ||
-        outputs.hi === undefined
-      ) {
-        return;
-      }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, rh, options } = inputs;
+    const modelResult = heat_index(tdb, rh, options);
 
-      const { tdb, rh, units } = inputs;
-      const options = units ? { units } : undefined; // Set options if units are provided
-
-      const result = heat_index(tdb, rh, options);
-
-      // Compare results
-      expect(result).toBeCloseTo(outputs.hi, tolerance);
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/humidex.test.js
+++ b/tests/models/humidex.test.js
@@ -1,33 +1,22 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import shared utilities
+import { describe } from "@jest/globals";
 import { humidex } from "../../src/models/humidex";
 import { testDataUrls } from "./comftest";
+import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
 
-let testData;
-let tolerance;
+let returnArray = false;
 
-beforeAll(async () => {
-  const result = await loadTestData(testDataUrls.humidex, "humidex"); // Use the correct tolerance key
-  testData = result.testData;
-  tolerance = result.tolerance;
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.humidex,
+  returnArray,
+);
 
 describe("humidex", () => {
-  it("should run tests after data is loaded and skip data with arrays", () => {
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Skip data that contains arrays
-      if (shouldSkipTest(inputs) || outputs === undefined) {
-        return;
-      }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, rh, options } = inputs;
+    const modelResult = humidex(tdb, rh, options);
 
-      const { tdb, rh, round } = inputs;
-      const options = round !== undefined ? { round } : undefined; // Add to options if round is provided
-
-      const result = humidex(tdb, rh, options);
-
-      // Compare results
-      expect(result.humidex).toBeCloseTo(outputs.humidex, tolerance);
-      expect(result.discomfort).toBe(outputs.discomfort);
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/pet_steady.test.js
+++ b/tests/models/pet_steady.test.js
@@ -1,34 +1,22 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import shared utilities
+import { describe } from "@jest/globals";
 import { pet_steady } from "../../src/models/pet_steady";
 import { testDataUrls } from "./comftest";
+import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
 
-let testData;
-let tolerance;
+let returnArray = false;
 
-beforeAll(async () => {
-  const result = await loadTestData(testDataUrls.petSteady, "PET"); // Use the correct tolerance key
-  testData = result.testData;
-  tolerance = result.tolerance;
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.petSteady,
+  returnArray,
+);
 
 describe("pet_steady", () => {
-  it("should run tests after data is loaded and skip data with arrays", () => {
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Skip data that contains arrays
-      if (
-        shouldSkipTest(inputs) ||
-        outputs === undefined ||
-        outputs.PET === undefined
-      ) {
-        return;
-      }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, tr, v, rh, met, clo } = inputs;
+    const modelResult = pet_steady(tdb, tr, v, rh, met, clo);
 
-      const { tdb, tr, v, rh, met, clo } = inputs;
-      const result = pet_steady(tdb, tr, v, rh, met, clo);
-
-      // Compare results
-      expect(result).toBeCloseTo(outputs.PET, tolerance);
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/pmv.test.js
+++ b/tests/models/pmv.test.js
@@ -1,31 +1,31 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Use modular utilities to load data and skip array checks
+import { describe } from "@jest/globals";
 import { pmv } from "../../src/models/pmv.js";
-import { testDataUrls } from "./comftest";
-
-let testData;
-let tolerance;
-
-beforeAll(async () => {
-  const result = await loadTestData(testDataUrls.pmv, "pmv"); // Load remote data and extract tolerance
-  testData = result.testData;
-  tolerance = result.tolerance;
-});
+import { validateResult } from "./testUtils.js";
 
 describe("pmv", () => {
-  it("should run tests after data is loaded and skip data containing arrays", () => {
-    if (!testData || !testData.data)
-      throw new Error("Data not loaded or undefined");
+  test("Test case with default parameters", () => {
+    const tolerances = {
+      pmv: 0.1,
+      ppd: 1,
+    };
 
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Use shouldSkipTest to check and skip data containing arrays
-      if (shouldSkipTest(inputs) || outputs === undefined) return;
+    const inputs = {
+      tdb: 22,
+      tr: 22,
+      rh: 60,
+      vr: 0.1,
+      met: 1.2,
+      clo: 0.5,
+      standard: "ISO",
+    };
 
-      const { tdb, tr, vr, rh, met, clo, standard } = inputs;
-      const result = pmv(tdb, tr, vr, rh, met, clo, undefined, standard);
+    const outputs = {
+      pmv: -0.8,
+    };
 
-      // Compare calculated result with expected output
-      expect(result).toBeCloseTo(outputs.pmv, tolerance);
-    });
+    const { tdb, tr, vr, rh, met, clo, wme, standard } = inputs;
+    const modelResult = { pmv: pmv(tdb, tr, vr, rh, met, clo, wme, standard) };
+
+    validateResult(modelResult, outputs, tolerances, inputs);
   });
 });

--- a/tests/models/pmv_ppd.test.js
+++ b/tests/models/pmv_ppd.test.js
@@ -1,84 +1,51 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import fetch from "node-fetch";
-import { pmv_ppd, pmv_calculation } from "../../src/models/pmv_ppd.js";
+import { describe, test } from "@jest/globals";
+import { pmv_ppd } from "../../src/models/pmv_ppd.js";
 import { testDataUrls } from "./comftest";
-import jest from "jest-mock";
+import { loadTestData, validateResult } from "./testUtils.js";
 
-const testDataUrl = testDataUrls.pmvPpd;
+let returnArray = false;
 
-let testData;
-let tolerance;
-
-beforeAll(async () => {
-  try {
-    const response = await fetch(testDataUrl);
-    if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
-    testData = await response.json();
-    tolerance = testData.tolerance || { pmv: 0.1, ppd: 0.01 }; // Add default tolerance
-  } catch (error) {
-    console.error("Failed to fetch test data:", error);
-    throw error;
-  }
-
-  // Disable console warnings
-  jest.spyOn(console, "warn").mockImplementation(() => {});
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.pmvPpd,
+  returnArray,
+);
 
 describe("pmv_pdd", () => {
-  it("should run tests and skip data that contains arrays or undefined fields", () => {
-    if (!testData || !testData.data)
-      throw new Error("Data not loaded or undefined");
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const {
+      tdb,
+      tr,
+      vr,
+      rh,
+      met,
+      clo,
+      wme,
+      standard,
+      units,
+      limit_inputs,
+      airspeed_control,
+    } = inputs;
 
-    testData.data.forEach(({ inputs, outputs }) => {
-      const values = Object.values(inputs);
-      const hasArray = values.some((value) => Array.isArray(value));
+    const kwargs = {
+      units,
+      limit_inputs,
+      airspeed_control,
+    };
 
-      if (hasArray || outputs === undefined) return; // Skip data with arrays or undefined
+    const modelResult = pmv_ppd(
+      tdb,
+      tr,
+      vr,
+      rh,
+      met,
+      clo,
+      wme,
+      standard,
+      kwargs,
+    );
 
-      const { tdb, tr, vr, rh, met, clo, standard } = inputs;
-      const result = pmv_ppd(tdb, tr, vr, rh, met, clo, undefined, standard);
-
-      // Check and handle PMV values
-      if (isNaN(result.pmv) || outputs.pmv === null) {
-        expect(result.pmv).toBeNaN();
-      } else if (outputs.pmv !== undefined && tolerance.pmv !== undefined) {
-        expect(result.pmv).toBeCloseTo(outputs.pmv, tolerance.pmv);
-      }
-
-      // Check and handle PPD values
-      if (isNaN(result.ppd) || outputs.ppd === null) {
-        expect(result.ppd).toBeNaN();
-      } else if (outputs.ppd !== undefined && tolerance.ppd !== undefined) {
-        expect(result.ppd).toBeCloseTo(outputs.ppd, tolerance.ppd);
-      }
-    });
-  });
-});
-
-describe("pmv_calculation", () => {
-  it("should run tests and skip data that contains arrays or undefined fields", () => {
-    if (!testData || !testData.data)
-      throw new Error("Data not loaded or undefined");
-
-    testData.data.forEach(({ inputs, outputs }) => {
-      const values = Object.values(inputs);
-      const hasArray = values.some((value) => Array.isArray(value));
-
-      if (hasArray || outputs === undefined) return; // Skip data with arrays or undefined
-
-      const { tdb, tr, vr, rh, met, clo, wme } = inputs;
-      const result = pmv_calculation(tdb, tr, vr, rh, met, clo, wme);
-
-      if (result.pmv === undefined) {
-        console.warn("Skipping due to undefined PMV result. Inputs:", inputs);
-        return;
-      }
-
-      if (isNaN(result.pmv) || outputs.pmv === null) {
-        expect(result.pmv).toBeNaN();
-      } else if (outputs.pmv !== undefined && tolerance.pmv !== undefined) {
-        expect(result.pmv).toBeCloseTo(outputs.pmv, tolerance.pmv);
-      }
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/solar_gain.test.js
+++ b/tests/models/solar_gain.test.js
@@ -1,78 +1,40 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import fetch from "node-fetch";
-import { find_span, solar_gain } from "../../src/models/solar_gain";
+import { describe } from "@jest/globals";
+import { solar_gain } from "../../src/models/solar_gain";
 import { testDataUrls } from "./comftest";
+import { loadTestData, validateResult } from "./testUtils";
 
-// Use the URL from comftest.js to fetch data for solar_gain tests
-const testDataUrl = testDataUrls.solarGain;
+let returnArray = false;
 
-let testData;
-let tolerance;
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.solarGain,
+  returnArray,
+);
 
-// Load data before all tests
-beforeAll(async () => {
-  const response = await fetch(testDataUrl);
-  if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
-
-  const fetchedData = await response.json();
-  testData = fetchedData.data || []; // Directly get the data field
-  tolerance = fetchedData.tolerance || {}; // Extract tolerance values
-});
-
-// Test code for find_span
-describe("find_span", () => {
-  it("should run tests after data is loaded", () => {
-    if (!testData || testData.length === 0) {
-      throw new Error("Find_span test data not loaded or undefined");
-    }
-
-    testData.forEach(({ inputs, outputs }) => {
-      if (!inputs.arr || !inputs.x) return;
-
-      const { arr, x } = inputs;
-      const result = find_span(arr, x);
-      expect(result).toBe(outputs.expected);
-    });
-  });
-});
-
-// Test code for solar_gain
 describe("solar_gain", () => {
-  it("should run solar_gain tests after data is loaded", () => {
-    if (!testData || testData.length === 0) {
-      throw new Error("Solar_gain test data not loaded or undefined");
-    }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const {
+      sol_altitude,
+      sharp,
+      sol_radiation_dir,
+      sol_transmittance,
+      f_svv,
+      f_bes,
+      asw,
+      posture,
+    } = inputs;
+    const modelResult = solar_gain(
+      sol_altitude,
+      sharp,
+      sol_radiation_dir,
+      sol_transmittance,
+      f_svv,
+      f_bes,
+      asw,
+      posture,
+    );
 
-    testData.forEach(({ inputs, outputs }) => {
-      if (!inputs.sol_altitude || !inputs.sol_radiation_dir) return;
-
-      const {
-        sol_altitude,
-        sharp,
-        sol_radiation_dir,
-        sol_transmittance,
-        f_svv,
-        f_bes,
-        asw,
-        posture,
-      } = inputs;
-
-      const result = solar_gain(
-        sol_altitude,
-        sharp,
-        sol_radiation_dir,
-        sol_transmittance,
-        f_svv,
-        f_bes,
-        asw,
-        posture,
-      );
-
-      expect(result.erf).toBeCloseTo(outputs.erf, tolerance.erf);
-      expect(result.delta_mrt).toBeCloseTo(
-        outputs.delta_mrt,
-        tolerance.delta_mrt,
-      );
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/testUtils.js
+++ b/tests/models/testUtils.js
@@ -54,8 +54,11 @@ export function validateResult(
         expectedOutputs[key] === null ? NaN : expectedOutputs[key];
       const actualValue = modelResult[key];
 
-      // expected output might contain variables whose tolerance is not defined
-      const tol = (tolerances && tolerances[key]) || 0;
+      // skip variables whose tolerance is not given
+      if (!tolerances || tolerances[key] === undefined) {
+        return;
+      }
+      const tol = tolerances[key];
 
       // Handle arrays
       if (Array.isArray(expectedValue)) {

--- a/tests/models/use_fans_heatwave.test.js
+++ b/tests/models/use_fans_heatwave.test.js
@@ -1,92 +1,51 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData, shouldSkipTest } from "./testUtils";
+import { describe, test } from "@jest/globals";
 import { use_fans_heatwaves } from "../../src/models/use_fans_heatwave";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
+import { loadTestData, validateResult } from "./testUtils";
 
-// Get data for use_fans_heatwaves tests
-const testDataUrl = testDataUrls.use_fans_heatwaves; // Ensure the correct URL is added in comftest.js
+let returnArray = false;
 
-let testData;
-let tolerance;
-
-// Load data before tests
-beforeAll(async () => {
-  const result = await loadTestData(testDataUrl, "use_fans_heatwaves");
-  testData = result.testData.data || []; // Ensure testData points to the data array
-  tolerance = result.tolerance || 1; // Use default tolerance
-});
-
-// Define result comparison logic within the test file
-function compareResults(result, expected, tolerance) {
-  for (let key in expected) {
-    if (isNaN(expected[key])) {
-      expect(result[key]).toBeNaN();
-    } else if (
-      key === "heat_strain" ||
-      key === "heat_strain_blood_flow" ||
-      key === "heat_strain_sweating" ||
-      key === "heat_strain_w"
-    ) {
-      expect(result[key]).toBe(expected[key]);
-    } else {
-      expect(result[key]).toBeCloseTo(expected[key], tolerance);
-    }
-  }
-}
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.use_fans_heatwaves,
+  returnArray,
+);
 
 describe("use_fans_heatwaves", () => {
-  it("should be a function", () => {
-    expect(use_fans_heatwaves).toBeInstanceOf(Function);
-  });
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const {
+      tdb,
+      tr,
+      v,
+      rh,
+      met,
+      clo,
+      wme,
+      body_surface_area,
+      p_atm,
+      position: body_position,
+      units,
+      max_skin_blood_flow,
+      kwargs,
+    } = inputs;
 
-  it("runs tests after data is loaded, skips array-based data", () => {
-    if (!testData || testData.length === 0) {
-      throw new Error("Test data is undefined or data not loaded");
-    }
+    const modelResult = use_fans_heatwaves(
+      tdb,
+      tr,
+      v,
+      rh,
+      met,
+      clo,
+      wme,
+      body_surface_area,
+      p_atm,
+      body_position,
+      units,
+      max_skin_blood_flow,
+      kwargs,
+    );
 
-    testData.forEach(({ inputs, expected }) => {
-      if (
-        shouldSkipTest(inputs) ||
-        expected === null ||
-        typeof expected === "object"
-      ) {
-        return; // Skip tests with array data or complex/empty expected values
-      }
-
-      const {
-        tdb,
-        tr,
-        v,
-        rh,
-        met,
-        clo,
-        wme,
-        body_surface_area,
-        p_atm,
-        body_position,
-        units,
-        max_skin_blood_flow,
-        kwargs,
-      } = inputs;
-
-      const result = use_fans_heatwaves(
-        tdb,
-        tr,
-        v,
-        rh,
-        met,
-        clo,
-        wme,
-        body_surface_area,
-        p_atm,
-        body_position,
-        units,
-        max_skin_blood_flow,
-        kwargs,
-      );
-
-      // Compare results using compareResults
-      compareResults(result, expected, tolerance);
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/utci.test.js
+++ b/tests/models/utci.test.js
@@ -1,93 +1,22 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { deep_close_to_array } from "../test_utilities";
-import { utci, utci_array } from "../../src/models/utci.js";
+import { describe } from "@jest/globals";
+import { utci } from "../../src/models/utci.js";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import utility functions
+import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
 
-// Variables to store data fetched from remote source
-let testData;
-let tolerance;
+let returnArray = false;
 
-// Fetch data before running tests
-beforeAll(async () => {
-  ({ testData, tolerance } = await loadTestData(testDataUrls.utci, "utci"));
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.utci,
+  returnArray,
+);
 
 describe("utci", () => {
-  it("should run tests and skip array or undefined fields", () => {
-    if (!testData || !testData.data) {
-      throw new Error("Test data is undefined or data not loaded");
-    }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, tr, rh, v, units, return_stress_category } = inputs;
+    const modelResult = utci(tdb, tr, v, rh, units, return_stress_category);
 
-    // Iterate over each test case
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Skip if any input value is an array
-      if (shouldSkipTest(inputs)) {
-        return; // Skip tests with array inputs
-      }
-
-      const { tdb, tr, rh, v, units, return_stress_category } = inputs;
-      const expected = outputs.utci;
-
-      // Skip comparison if expected is null, an object, or return_stress_category is set
-      if (
-        expected === null ||
-        typeof expected === "object" ||
-        return_stress_category
-      ) {
-        return;
-      }
-
-      // Calculate UTCI
-      const result = utci(tdb, tr, v, rh, units, return_stress_category);
-
-      if (isNaN(expected)) {
-        expect(result).toBeNaN();
-      } else {
-        expect(result).toBeCloseTo(expected, tolerance);
-      }
-    });
-  });
-});
-
-describe("utci_array", () => {
-  it("should skip array input testing", () => {
-    if (!testData || !testData.data) {
-      throw new Error("Test data is undefined or data not loaded");
-    }
-
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Check if array inputs are present, and skip if so
-      if (shouldSkipTest(inputs)) {
-        return;
-      }
-
-      const { tdb, tr, rh, v, units } = inputs;
-      const expected = outputs.utci_array;
-
-      // Skip if valid array inputs are not provided
-      if (
-        !Array.isArray(tdb) ||
-        !Array.isArray(tr) ||
-        !Array.isArray(v) ||
-        !Array.isArray(rh)
-      ) {
-        return;
-      }
-
-      // Calculate UTCI array
-      const result = utci_array(tdb, tr, v, rh, units);
-
-      // Compare each array result
-      deep_close_to_array(result.utci, expected.utci, tolerance);
-
-      // Ensure stress_category lengths are the same
-      expect(result.stress_category.length).toBe(
-        expected.stress_category.length,
-      );
-      for (let i = 0; i < result.stress_category.length; i++) {
-        expect(result.stress_category[i]).toBe(expected.stress_category[i]);
-      }
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/vertical_tmp_grad_ppd.test.js
+++ b/tests/models/vertical_tmp_grad_ppd.test.js
@@ -1,83 +1,31 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
+import { describe } from "@jest/globals";
 import { vertical_tmp_grad_ppd } from "../../src/models/vertical_tmp_grad_ppd";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import utility functions
+import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
 
-// Variables to store data fetched from remote source
-let testData;
-let tolerance;
+let returnArray = false;
 
-// Fetch data before running tests
-beforeAll(async () => {
-  ({ testData, tolerance } = await loadTestData(
-    testDataUrls.verticalTmpGradPpd,
-    "PPD_vg",
-  ));
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.verticalTmpGradPpd,
+  returnArray,
+);
 
 describe("vertical_tmp_grad_ppd", () => {
-  it("should run tests and handle vr > 0.2 m/s with error checking", () => {
-    if (!testData || !testData.data) {
-      throw new Error("Test data is undefined or data not loaded");
-    }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, tr, vr, rh, met, clo, vertical_tmp_grad, units } = inputs;
+    const modelResult = vertical_tmp_grad_ppd(
+      tdb,
+      tr,
+      vr,
+      rh,
+      met,
+      clo,
+      vertical_tmp_grad,
+      units,
+    );
 
-    // Iterate over each test case
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Use utility function to skip tests with array inputs
-      if (shouldSkipTest(inputs) || outputs === undefined) {
-        return;
-      }
-
-      const { tdb, tr, vr, rh, met, clo, vertical_tmp_grad, units } = inputs;
-
-      // Check input range to ensure it’s within ASHRAE recommended range
-      if (tdb < 10 || tdb > 40 || tr < 10 || tr > 40) {
-        return;
-      }
-
-      // Skip this data set if any input value is invalid
-      if (
-        [tdb, tr, vr, rh, met, clo, vertical_tmp_grad].some((value) =>
-          isNaN(value),
-        )
-      ) {
-        return;
-      }
-
-      try {
-        const result = vertical_tmp_grad_ppd(
-          tdb,
-          tr,
-          vr,
-          rh,
-          met,
-          clo,
-          vertical_tmp_grad,
-          units,
-        );
-
-        // Handle cases where PPD_vg is NaN
-        if (isNaN(result.PPD_vg) || outputs.PPD_vg === null) {
-          expect(result.PPD_vg).toBeNaN();
-        } else if (outputs.PPD_vg !== undefined) {
-          // If output is not NaN, compare values
-          expect(result.PPD_vg).toBeCloseTo(outputs.PPD_vg, tolerance);
-        }
-
-        // Check Acceptability only if it’s defined in outputs
-        if (outputs.Acceptability !== undefined) {
-          expect(result.Acceptability).toBe(outputs.Acceptability);
-        }
-      } catch (error) {
-        // Capture and check specific error messages
-        if (vr > 0.2) {
-          expect(error.message).toBe(
-            "This equation is only applicable for air speed lower than 0.2 m/s",
-          );
-        } else {
-          throw error; // Re-throw error if unrelated to air speed
-        }
-      }
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });

--- a/tests/models/wbgt.test.js
+++ b/tests/models/wbgt.test.js
@@ -1,45 +1,23 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
+import { describe, expect, it, test } from "@jest/globals";
 import { wbgt } from "../../src/models/wbgt";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
-import { loadTestData } from "./testUtils"; // Import utility functions
+import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
 
-// Variables to store data fetched from remote source
-let testData;
-let tolerance;
+let returnArray = false;
 
-// Fetch data before running tests
-beforeAll(async () => {
-  ({ testData, tolerance } = await loadTestData(testDataUrls.wbgt, "wbgt"));
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(
+  testDataUrls.wbgt,
+  returnArray,
+);
 
 describe("wbgt", () => {
-  it("should run tests and skip invalid data or handle errors gracefully", () => {
-    if (!testData || !testData.data) {
-      throw new Error("Test data is undefined or data not loaded");
-    }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { twb, tg, tdb, with_solar_load, round } = inputs;
+    const modelResult = wbgt(twb, tg, { tdb, with_solar_load, round });
 
-    // Iterate over each test case
-    testData.data.forEach(({ inputs, outputs }) => {
-      const { twb, tg, tdb, with_solar_load, round } = inputs;
-
-      try {
-        const result = wbgt(twb, tg, { tdb, with_solar_load, round });
-
-        // Verify if the return value is close to the expected value
-        if (outputs.wbgt !== undefined) {
-          expect(result).toBeCloseTo(outputs.wbgt, tolerance);
-        }
-      } catch (error) {
-        // Capture and handle specific error messages
-        if (with_solar_load && tdb === undefined) {
-          expect(error.message).toBe(
-            "Please enter the dry bulb air temperature",
-          );
-        } else {
-          throw error; // Re-throw if it’s another error
-        }
-      }
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 
   it("should throw an error when with_solar_load is set and tdb is not provided", () => {

--- a/tests/models/wc.test.js
+++ b/tests/models/wc.test.js
@@ -1,35 +1,20 @@
-import { describe, it, beforeAll } from "@jest/globals";
+import { describe } from "@jest/globals";
 import { wc } from "../../src/models/wc.js";
-import { deep_close_to_obj } from "../test_utilities.js";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
-import { loadTestData, shouldSkipTest } from "./testUtils"; // Import utility functions
+import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
 
-// Variables to store data fetched from remote source
-let testData;
-let tolerance;
+let returnArray = false;
 
-// Fetch data before running tests
-beforeAll(async () => {
-  ({ testData, tolerance } = await loadTestData(testDataUrls.wc, "wc"));
-});
+// use top-level await to load test data before tests are defined.
+let { testData, tolerances } = await loadTestData(testDataUrls.wc, returnArray);
 
 describe("test_wc", () => {
-  it("should run tests and skip data that contains arrays or undefined fields", () => {
-    if (!testData || !testData.data) {
-      throw new Error("Test data is undefined or data not loaded");
-    }
+  test.each(testData.data)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, v, round } = inputs;
+    const kwargs = { round };
+    const modelResult = wc(tdb, v, kwargs);
 
-    testData.data.forEach(({ inputs, expected }) => {
-      // Use shouldSkipTest to skip data containing array inputs
-      if (shouldSkipTest(inputs) || expected === undefined) {
-        return;
-      }
-
-      const { tdb, v } = inputs;
-      const result = wc(tdb, v);
-
-      // Compare calculated results
-      deep_close_to_obj(result, expected, tolerance);
-    });
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });


### PR DESCRIPTION
This PR contains most of the tests that are passing after refactoring. The following tests are not updated yet because some of them are failing. 

- `pet_steady.test.js` (2 cases)
- `phs.test.js` (all failing)
- `set_tmp.js` (5 cases)
	- some input values are invalid
- `utci.test.js` (2 cases)
	- these test cases have no input parameter `return_stress_category`, but the expected output contains the `stress_category`
- `pmv.test.js` (validation table does not exist from the given url)