### PR TITLE
fix: adaptive model tolerance mismatch and validateResult absolute tolerance comparison

### DIFF
--- a/tests/models/adaptive_ashrae.test.js
+++ b/tests/models/adaptive_ashrae.test.js
@@ -5,7 +5,7 @@ import { loadTestData, validateResult } from "./testUtils";
 
 let returnArray = false;
 
-let { testData, tolerance } = await loadTestData(
+let { testData, tolerances } = await loadTestData(
   testDataUrls.adaptiveAshrae,
   returnArray,
 );
@@ -16,6 +16,54 @@ describe("adaptive_ashrae", () => {
     const { tdb, tr, t_running_mean, v, units } = inputs;
     const modelResult = adaptive_ashrae(tdb, tr, t_running_mean, v, units);
 
-    validateResult(modelResult, expectedOutput, tolerance, inputs);
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scalar hardcoded tests
+// Expected values obtained from pythermalcomfort reference implementation.
+//
+// Scenarios covered:
+//   SC-1  Neutral comfort, t_running_mean within range → comfort predicted
+//   SC-2  Warm indoor exceeds comfort zone → not acceptable
+//   SC-3  Cool indoor below comfort zone → not acceptable
+//   SC-4  Out-of-range t_running_mean → tmp_cmf is NaN
+//   SC-5  IP units conversion
+// ---------------------------------------------------------------------------
+describe("adaptive_ashrae scalar tests (hardcoded)", () => {
+  test("SC-1 Neutral comfort, t_running_mean within range → comfort predicted", () => {
+    const result = adaptive_ashrae(25, 25, 20, 0.1);
+    validateResult(result, { tmp_cmf: 24.0 }, tolerances, {});
+    expect(result.acceptability_80).toBe(true);
+    expect(result.acceptability_90).toBe(true);
+  });
+
+  test("SC-2 Warm indoor exceeds comfort zone → not acceptable", () => {
+    const result = adaptive_ashrae(32, 32, 20, 0.1);
+    validateResult(result, { tmp_cmf: 24.0 }, tolerances, {});
+    expect(result.acceptability_80).toBe(false);
+    expect(result.acceptability_90).toBe(false);
+  });
+
+  test("SC-3 Cool indoor below comfort zone → not acceptable", () => {
+    const result = adaptive_ashrae(15, 15, 12, 0.1);
+    validateResult(result, { tmp_cmf: 21.5 }, tolerances, {});
+    expect(result.acceptability_80).toBe(false);
+    expect(result.acceptability_90).toBe(false);
+  });
+
+  test("SC-4 Out-of-range t_running_mean → tmp_cmf is NaN", () => {
+    const result = adaptive_ashrae(25, 25, 5, 0.1, "SI", true);
+    expect(result.tmp_cmf).toBeNaN();
+    expect(result.acceptability_80).toBe(false);
+    expect(result.acceptability_90).toBe(false);
+  });
+
+  test("SC-5 IP units conversion", () => {
+    const result = adaptive_ashrae(77, 77, 68, 0.3, "IP");
+    validateResult(result, { tmp_cmf: 75.2 }, tolerances, {});
+    expect(result.acceptability_80).toBe(true);
+    expect(result.acceptability_90).toBe(true);
   });
 });

--- a/tests/models/adaptive_en.test.js
+++ b/tests/models/adaptive_en.test.js
@@ -5,7 +5,7 @@ import { loadTestData, validateResult } from "./testUtils"; // use the utils
 
 let returnArray = false;
 
-let { testData, tolerance } = await loadTestData(
+let { testData, tolerances } = await loadTestData(
   testDataUrls.adaptiveEn,
   returnArray,
 );
@@ -16,6 +16,59 @@ describe("adaptive_en", () => {
     const { tdb, tr, t_running_mean, v, units } = inputs;
     const modelResult = adaptive_en(tdb, tr, t_running_mean, v, units);
 
-    validateResult(modelResult, expectedOutput, tolerance, inputs);
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scalar hardcoded tests
+// Expected values obtained from pythermalcomfort reference implementation.
+//
+// Scenarios covered:
+//   SC-1  Neutral comfort, t_running_mean within range → all categories acceptable
+//   SC-2  Warm indoor exceeds comfort zone → not acceptable in any category
+//   SC-3  Cool indoor below comfort zone → not acceptable in any category
+//   SC-4  Out-of-range t_running_mean → tmp_cmf is NaN
+//   SC-5  Higher air speed → wider comfort range
+// ---------------------------------------------------------------------------
+describe("adaptive_en scalar tests (hardcoded)", () => {
+  test("SC-1 Neutral comfort, t_running_mean within range → all categories acceptable", () => {
+    const result = adaptive_en(25, 25, 20, 0.1);
+    validateResult(result, { tmp_cmf: 25.4 }, tolerances, {});
+    expect(result.acceptability_cat_i).toBe(true);
+    expect(result.acceptability_cat_ii).toBe(true);
+    expect(result.acceptability_cat_iii).toBe(true);
+  });
+
+  test("SC-2 Warm indoor exceeds comfort zone → not acceptable in any category", () => {
+    const result = adaptive_en(30, 30, 20, 0.1);
+    validateResult(result, { tmp_cmf: 25.4 }, tolerances, {});
+    expect(result.acceptability_cat_i).toBe(false);
+    expect(result.acceptability_cat_ii).toBe(false);
+    expect(result.acceptability_cat_iii).toBe(false);
+  });
+
+  test("SC-3 Cool indoor below comfort zone → not acceptable in any category", () => {
+    const result = adaptive_en(17, 17, 12, 0.1);
+    validateResult(result, { tmp_cmf: 22.8 }, tolerances, {});
+    expect(result.acceptability_cat_i).toBe(false);
+    expect(result.acceptability_cat_ii).toBe(false);
+    expect(result.acceptability_cat_iii).toBe(false);
+  });
+
+  test("SC-4 Out-of-range t_running_mean → tmp_cmf is NaN", () => {
+    const result = adaptive_en(25, 25, 8, 0.1, "SI", true);
+    expect(result.tmp_cmf).toBeNaN();
+    expect(result.acceptability_cat_i).toBe(false);
+    expect(result.acceptability_cat_ii).toBe(false);
+    expect(result.acceptability_cat_iii).toBe(false);
+  });
+
+  test("SC-5 Higher air speed → wider comfort range", () => {
+    const result = adaptive_en(27, 27, 22, 0.6);
+    validateResult(result, { tmp_cmf: 26.1 }, tolerances, {});
+    expect(result.acceptability_cat_i).toBe(true);
+    expect(result.acceptability_cat_ii).toBe(true);
+    expect(result.acceptability_cat_iii).toBe(true);
   });
 });

--- a/tests/models/testUtils.js
+++ b/tests/models/testUtils.js
@@ -69,7 +69,9 @@ export function validateResult(
             if (isNaN(exp)) {
               expect(act).toBeNaN();
             } else {
-              expect(act).toBeCloseTo(exp, tol);
+              expect(Math.abs(act - exp)).toBeLessThanOrEqual(
+                tol + Number.EPSILON * 100,
+              );
             }
           } else {
             expect(act).toEqual(exp);
@@ -80,7 +82,9 @@ export function validateResult(
         if (isNaN(expectedValue)) {
           expect(actualValue).toBeNaN();
         } else {
-          expect(actualValue).toBeCloseTo(expectedValue, tol);
+          expect(Math.abs(actualValue - expectedValue)).toBeLessThanOrEqual(
+            tol + Number.EPSILON * 100,
+          );
         }
       } else {
         // For booleans or other types


### PR DESCRIPTION
## What this PR does
- Fix `tolerance` variable name mismatch in `adaptive_ashrae.test.js` and `adaptive_en.test.js` where `loadTestData` returns `tolerances` (plural) but was destructured as `tolerance` (singular), causing all validation checks to be silently skipped
- Fix `validateResult` in `testUtils.js` using `toBeCloseTo` to compare numeric values instead of absolute tolerance, which produces inconsistent strictness depending on the tolerance value
- Add simple tests for `adaptive_ashrae` and `adaptive_en`

## Why this change is needed
- The validation data tests for `adaptive_ashrae` and `adaptive_en` were passing vacuously — since `tolerance` was `undefined`, `validateResult` silently skipped every field and made no actual comparisons. Any regression in these models would not have been caught.
- `toBeCloseTo(expected, tol)` treats `tol` as decimal places, not absolute tolerance. For example, a tolerance of `1` becomes a check of `± 0.05`, which is far stricter than intended. Replacing it with `Math.abs(actual - expected) <= tol` ensures the comparison matches the intended behaviour defined in the validation data.

## How I tested it
- [x] npm test

## Notes for reviewers
- The `tolerance` → `tolerances` rename only affects `adaptive_ashrae.test.js` and `adaptive_en.test.js`. Other test files already use the correct variable name.
- The `validateResult` fix affects all models. Existing tests were re-run to confirm no regressions.
- Hardcoded tests use `validateResult` for numeric fields and direct `expect` for boolean fields such as `acceptability_80` and `acceptability_cat_i`, since boolean fields are not covered by the validation data tolerances.