### PR TITLE
refactor: add input type validation to core model functions

### DIFF
--- a/src/models/a_pmv.js
+++ b/src/models/a_pmv.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { pmv } from "./pmv.js";
 
 /**
@@ -81,6 +82,10 @@ export function a_pmv(
   wme = 0,
   kwargs = {},
 ) {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, clo, a_coefficient, wme)) {
+    return { a_pmv: NaN };
+  }
+
   const default_kwargs = {
     units: "SI",
     limit_inputs: true,

--- a/src/models/adaptive_ashrae.js
+++ b/src/models/adaptive_ashrae.js
@@ -4,6 +4,7 @@ import {
   round,
   units_converter,
 } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { get_ce } from "./adaptive_en.js";
 
 /**
@@ -88,6 +89,18 @@ export function adaptive_ashrae(
   units = "SI",
   limit_inputs = true,
 ) {
+  if (!allValidNumbers(tdb, tr, t_running_mean, v)) {
+    return {
+      tmp_cmf: NaN,
+      tmp_cmf_80_low: NaN,
+      tmp_cmf_80_up: NaN,
+      tmp_cmf_90_low: NaN,
+      tmp_cmf_90_up: NaN,
+      acceptability_80: false,
+      acceptability_90: false,
+    };
+  }
+
   const standard = "ASHRAE";
   if (units.toUpperCase() === "IP") {
     ({

--- a/src/models/adaptive_en.js
+++ b/src/models/adaptive_en.js
@@ -1,5 +1,6 @@
 import { t_o } from "../psychrometrics/t_o.js";
 import { units_converter, round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {object} AdaptiveEnResult - a result set containing the results for {@link #adative_en|adaptive_en}
@@ -60,7 +61,7 @@ import { units_converter, round } from "../utilities/utilities.js";
  *
  * @example
  * const results = adaptive_en(25, 25, 9, 0.1);
- * console.log(results); // {tmp_cmf: NaN, acceptability_cat_i: true, acceptability_cat_ii: true, ... }
+ * console.log(results); // {tmp_cmf: NaN, acceptability_cat_i: false, acceptability_cat_ii: false, ... }
  * // The adaptive thermal comfort model can only be used
  * // if the running mean temperature is between 10 °C and 30 °C
  */
@@ -73,6 +74,21 @@ export function adaptive_en(
   limit_inputs = true,
 ) {
   const standard = "ISO";
+
+  if (!allValidNumbers(tdb, tr, t_running_mean, v)) {
+    return {
+      tmp_cmf: NaN,
+      acceptability_cat_i: false,
+      acceptability_cat_ii: false,
+      acceptability_cat_iii: false,
+      tmp_cmf_cat_i_up: NaN,
+      tmp_cmf_cat_ii_up: NaN,
+      tmp_cmf_cat_iii_up: NaN,
+      tmp_cmf_cat_i_low: NaN,
+      tmp_cmf_cat_ii_low: NaN,
+      tmp_cmf_cat_iii_low: NaN,
+    };
+  }
 
   if (units.toLowerCase() == "ip") {
     ({

--- a/src/models/ankle_draft.js
+++ b/src/models/ankle_draft.js
@@ -3,6 +3,7 @@ import {
   round,
   units_converter,
 } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { pmv } from "./pmv.js";
 
 /**
@@ -55,6 +56,10 @@ import { pmv } from "./pmv.js";
  * 
  */
 export function ankle_draft(tdb, tr, vr, rh, met, clo, v_ankle, units = "SI") {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, clo, v_ankle)) {
+    return { ppd_ad: NaN, acceptability: false };
+  }
+
   let kwargs = {};
   let ret = 0;
   if (units.toLowerCase() == "ip") {

--- a/src/models/at.js
+++ b/src/models/at.js
@@ -1,5 +1,9 @@
 import { psy_ta_rh } from "../psychrometrics/psy_ta_rh.js";
 import { round } from "../utilities/utilities.js";
+import {
+  allValidNumbers,
+  isValidNumber,
+} from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {object} AtResult
@@ -38,6 +42,10 @@ import { round } from "../utilities/utilities.js";
  * console.log(result); // {at: 24.1}
  */
 export function at(tdb, rh, v, q, kwargs = { round: true }) {
+  if (!allValidNumbers(tdb, rh, v) || (q !== undefined && !isValidNumber(q))) {
+    return { at: NaN };
+  }
+
   // dividing it by 100 since the at eq. requires p_vap to be in hPa
   const p_vap = psy_ta_rh(tdb, rh).p_vap / 100;
   let t_at;

--- a/src/models/athb.js
+++ b/src/models/athb.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { pmv_calculation } from "./pmv_ppd.js";
 
 /**
@@ -52,6 +53,10 @@ import { pmv_calculation } from "./pmv_ppd.js";
  * console.log(athb_result); // Output: {athb_pmv: 0.2}
  */
 export function athb(tdb, tr, vr, rh, met, t_running_mean) {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, t_running_mean)) {
+    return { athb_pmv: NaN };
+  }
+
   const met_adapted = met - (0.234 * t_running_mean) / 58.2;
 
   const clo_adapted = Math.pow(

--- a/src/models/clo_tout.js
+++ b/src/models/clo_tout.js
@@ -1,4 +1,5 @@
 import { round, units_converter } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {object} CloToutResult
@@ -27,6 +28,10 @@ import { round, units_converter } from "../utilities/utilities.js";
  * @returns {CloToutResult} set containing results for the model
  */
 export function clo_tout(tout, units = "SI") {
+  if (!allValidNumbers(tout)) {
+    return { clo_tout: NaN };
+  }
+
   const t = units === "IP" ? units_converter({ tmp: tout }).tmp : tout;
 
   let clo = t < 26 ? 10 ** (-0.1635 - 0.0066 * t) : 0.46;

--- a/src/models/cooling_effect.js
+++ b/src/models/cooling_effect.js
@@ -1,4 +1,5 @@
 import { round, units_converter } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { set_tmp } from "./set_tmp.js";
 
 /**
@@ -62,6 +63,10 @@ export function cooling_effect(
   wme = 0,
   units = "SI",
 ) {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, clo, wme)) {
+    return { ce: NaN };
+  }
+
   if (units.toLowerCase() === "ip") {
     const result = units_converter({ tdb, tr, vr }, "IP");
     tdb = result.tdb;

--- a/src/models/discomfort_index.js
+++ b/src/models/discomfort_index.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {Object} DiscomfortIndexReturnType - a result set containing the discomfort index and the classification of the
@@ -32,6 +33,10 @@ import { round } from "../utilities/utilities.js";
  * const DI = discomfort_index(25, 50); // returns { di: 22.1, discomfort_condition: 'Less than 50% feels discomfort' }
  */
 export function discomfort_index(tdb, rh) {
+  if (!allValidNumbers(tdb, rh)) {
+    return { di: NaN, discomfort_condition: NaN };
+  }
+
   const di = calculate_di(tdb, rh);
   const condition = check_categories(di);
 

--- a/src/models/e_pmv.js
+++ b/src/models/e_pmv.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { pmv } from "./pmv.js";
 
 /**
@@ -84,6 +85,10 @@ export function e_pmv(
   wme = 0,
   kwargs = {},
 ) {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, clo, e_coefficient, wme)) {
+    return { e_pmv: NaN };
+  }
+
   const default_kwargs = {
     units: "SI",
     limit_inputs: true,

--- a/src/models/heat_index.js
+++ b/src/models/heat_index.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {object} HeatIndexResult
@@ -28,6 +29,10 @@ import { round } from "../utilities/utilities.js";
  * @category Thermophysiological models
  */
 export function heat_index(tdb, rh, options = { round: true, units: "SI" }) {
+  if (!allValidNumbers(tdb, rh)) {
+    return { hi: NaN };
+  }
+
   let hi;
   let tdb_squared = Math.pow(tdb, 2);
   let rh_squared = Math.pow(rh, 2);

--- a/src/models/humidex.js
+++ b/src/models/humidex.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {object} HumidexResult - a result set containing the humidex and
@@ -36,6 +37,10 @@ import { round } from "../utilities/utilities.js";
  * console.log(result); // -> { humidex: 28.2, discomfort: "Little or no discomfort" }
  */
 export function humidex(tdb, rh, options = { round: true }) {
+  if (!allValidNumbers(tdb, rh)) {
+    return { humidex: NaN, discomfort: NaN };
+  }
+
   let hi =
     tdb +
     (5 / 9) * ((6.112 * 10 ** ((7.5 * tdb) / (237.7 + tdb)) * rh) / 100 - 10);

--- a/src/models/net.js
+++ b/src/models/net.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 /**
  * @typedef {object} NetResult
  * @property {number} net - Normal Effective Temperature, [°C]
@@ -41,6 +42,10 @@ import { round } from "../utilities/utilities.js";
  * console.log(result); // -> {net: 37}
  */
 export function net(tdb, rh, v, options = { round: true }) {
+  if (!allValidNumbers(tdb, rh, v)) {
+    return { net: NaN };
+  }
+
   const frac = 1.0 / (1.76 + 1.4 * v ** 0.75);
   let et =
     37 -

--- a/src/models/pet_steady.js
+++ b/src/models/pet_steady.js
@@ -1,5 +1,6 @@
 import { p_sat } from "../psychrometrics/p_sat.js";
 import { body_surface_area, round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {object} PetSteadyResult
@@ -70,6 +71,26 @@ export function pet_steady(
   height = 1.8,
   wme = 0,
 ) {
+  if (
+    !allValidNumbers(
+      tdb,
+      tr,
+      v,
+      rh,
+      met,
+      clo,
+      p_atm,
+      position,
+      age,
+      sex,
+      weight,
+      height,
+      wme,
+    )
+  ) {
+    return { pet: NaN };
+  }
+
   const met_factor = 58.2; // met conversion factor
   met = met * met_factor; // metabolic rate
 

--- a/src/models/phs.js
+++ b/src/models/phs.js
@@ -4,6 +4,10 @@ import {
   check_standard_compliance,
   round,
 } from "../utilities/utilities.js";
+import {
+  allValidNumbers,
+  isValidNumber,
+} from "../utilities/validate_inputs.js";
 
 const MET_WATT_PER_MET = 58.15;
 
@@ -115,6 +119,28 @@ export function phs(
   model = "7933-2023",
   kwargs = {},
 ) {
+  const postureValid =
+    typeof posture === "number"
+      ? isValidNumber(posture)
+      : typeof posture === "string" &&
+        ["sitting", "standing", "crouching"].includes(posture.toLowerCase());
+
+  if (!allValidNumbers(tdb, tr, v, rh, met, clo, wme) || !postureValid) {
+    return {
+      t_re: NaN,
+      t_sk: NaN,
+      t_cr: NaN,
+      t_cr_eq: NaN,
+      t_sk_t_cr_wg: NaN,
+      d_lim_loss_50: NaN,
+      d_lim_loss_95: NaN,
+      d_lim_t_re: NaN,
+      sweat_rate_watt: NaN,
+      sweat_loss_g: NaN,
+      evap_load_wm2_min: NaN,
+    };
+  }
+
   const defaults_kwargs = {
     i_mst: 0.38,
     a_p: 0.54,

--- a/src/models/pmv.js
+++ b/src/models/pmv.js
@@ -1,3 +1,4 @@
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { pmv_ppd } from "./pmv_ppd.js";
 
 /**
@@ -105,6 +106,10 @@ export function pmv(
   standard = "ISO",
   kwargs = {},
 ) {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, clo, wme)) {
+    return NaN;
+  }
+
   const default_kwargs = {
     units: "SI",
     limit_inputs: true,

--- a/src/models/pmv_ppd.js
+++ b/src/models/pmv_ppd.js
@@ -4,6 +4,7 @@ import {
   units_converter,
   valid_range,
 } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 import { cooling_effect } from "./cooling_effect.js";
 
 /**
@@ -120,6 +121,10 @@ export function pmv_ppd(
   standard = "ISO",
   kwargs = {},
 ) {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, clo, wme)) {
+    return { pmv: NaN, ppd: NaN };
+  }
+
   const default_kwargs = {
     units: "SI",
     limit_inputs: true,

--- a/src/models/set_tmp.js
+++ b/src/models/set_tmp.js
@@ -4,6 +4,10 @@ import {
   round,
   units_converter,
 } from "../utilities/utilities.js";
+import {
+  allValidNumbers,
+  isValidNumber,
+} from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {Object} SetTmpResult
@@ -69,6 +73,14 @@ export function set_tmp(
   limit_inputs = true,
   kwargs = {},
 ) {
+  if (
+    !allValidNumbers(tdb, tr, v, rh, met, clo, wme) ||
+    (body_surface_area !== undefined && !isValidNumber(body_surface_area)) ||
+    (p_atm !== undefined && !isValidNumber(p_atm))
+  ) {
+    return { set: NaN };
+  }
+
   const defaults_kwargs = {
     calculate_ce: false,
     round: true,

--- a/src/models/solar_gain.js
+++ b/src/models/solar_gain.js
@@ -1,4 +1,5 @@
 import { round, transpose_sharp_altitude } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 // avoid reallocating these arrays accross function calls
 const _alt_range = [0, 15, 30, 45, 60, 75, 90];
@@ -104,6 +105,21 @@ export function solar_gain(
   posture = "sitting",
   floor_reflectance = 0.6,
 ) {
+  if (
+    !allValidNumbers(
+      sol_altitude,
+      sharp,
+      sol_radiation_dir,
+      sol_transmittance,
+      f_svv,
+      f_bes,
+      asw,
+      floor_reflectance,
+    )
+  ) {
+    return { erf: NaN, delta_mrt: NaN };
+  }
+
   posture = posture.toLowerCase();
   if (posture !== "standing" && posture !== "supine" && posture !== "sitting")
     throw new Error("Posture has to be either standing, supine or sitting");

--- a/src/models/two_nodes.js
+++ b/src/models/two_nodes.js
@@ -1,5 +1,6 @@
 import { p_sat_torr } from "../psychrometrics/p_sat_torr.js";
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {Object} TwoNodesReturnType
@@ -127,6 +128,71 @@ export function two_nodes(
   max_skin_blood_flow = 90,
   kwargs = {},
 ) {
+  if (
+    !allValidNumbers(
+      tdb,
+      tr,
+      v,
+      rh,
+      met,
+      clo,
+      wme,
+      body_surface_area,
+      p_atmospheric,
+      max_skin_blood_flow,
+    )
+  ) {
+    const earlyKwargs = Object.assign(
+      { round: true, calculate_ce: false },
+      kwargs,
+    );
+    if (earlyKwargs.calculate_ce) {
+      return { set: NaN };
+    }
+    if (earlyKwargs.round) {
+      return {
+        e_skin: NaN,
+        e_rsw: NaN,
+        e_max: NaN,
+        q_sensible: NaN,
+        q_skin: NaN,
+        q_res: NaN,
+        t_core: NaN,
+        t_skin: NaN,
+        m_bl: NaN,
+        m_rsw: NaN,
+        w: NaN,
+        w_max: NaN,
+        set: NaN,
+        et: NaN,
+        pmv_gagge: NaN,
+        pmv_set: NaN,
+        disc: NaN,
+        t_sens: NaN,
+      };
+    }
+    return {
+      set: NaN,
+      eSkin: NaN,
+      eRsw: NaN,
+      eMax: NaN,
+      qSensible: NaN,
+      qSkin: NaN,
+      qRes: NaN,
+      tCore: NaN,
+      tSkin: NaN,
+      mBl: NaN,
+      mRsw: NaN,
+      w: NaN,
+      wMax: NaN,
+      et: NaN,
+      pmvGagge: NaN,
+      pmvSet: NaN,
+      disc: NaN,
+      tSens: NaN,
+    };
+  }
+
   const defaults_kwargs = {
     calculate_ce: false,
     round: true,

--- a/src/models/use_fans_heatwave.js
+++ b/src/models/use_fans_heatwave.js
@@ -3,6 +3,10 @@ import {
   check_standard_compliance_array,
   round,
 } from "../utilities/utilities.js";
+import {
+  allValidNumbers,
+  isValidNumber,
+} from "../utilities/validate_inputs.js";
 import { two_nodes } from "../models/two_nodes.js";
 
 /**
@@ -114,6 +118,55 @@ export function use_fans_heatwaves(
   max_skin_blood_flow = 80,
   kwargs = {},
 ) {
+  if (
+    !allValidNumbers(tdb, tr, v, rh, met, clo, wme, max_skin_blood_flow) ||
+    (body_surface_area !== undefined && !isValidNumber(body_surface_area)) ||
+    (p_atm !== undefined && !isValidNumber(p_atm))
+  ) {
+    const earlyKwargs = Object.assign({ round: true }, kwargs);
+    if (earlyKwargs.round) {
+      return {
+        e_skin: NaN,
+        e_rsw: NaN,
+        e_max: NaN,
+        q_sensible: NaN,
+        q_skin: NaN,
+        q_res: NaN,
+        t_core: NaN,
+        t_skin: NaN,
+        m_bl: NaN,
+        m_rsw: NaN,
+        w: NaN,
+        w_max: NaN,
+        heat_strain_blood_flow: undefined,
+        heat_strain_w: undefined,
+        heat_strain_sweating: undefined,
+        heat_strain: undefined,
+      };
+    }
+    return {
+      eSkin: NaN,
+      eRsw: NaN,
+      eMax: NaN,
+      qSensible: NaN,
+      qSkin: NaN,
+      qRes: NaN,
+      tCore: NaN,
+      tSkin: NaN,
+      mBl: NaN,
+      mRsw: NaN,
+      w: NaN,
+      wMax: NaN,
+      pmvGagge: NaN,
+      pmvSet: NaN,
+      tSens: NaN,
+      heat_strain_blood_flow: undefined,
+      heat_strain_w: undefined,
+      heat_strain_sweating: undefined,
+      heat_strain: undefined,
+    };
+  }
+
   const defaults_kwargs = {
     round: true,
     max_sweating: 500,

--- a/src/models/utci.js
+++ b/src/models/utci.js
@@ -1,4 +1,5 @@
 import { round, units_converter, valid_range } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 const g = [
   -2836.5744,
@@ -69,6 +70,13 @@ export function utci(
   return_stress_category = false,
   limit_inputs = true,
 ) {
+  if (!allValidNumbers(tdb, tr, v, rh)) {
+    if (return_stress_category) {
+      return { utci: NaN, stress_category: NaN };
+    }
+    return { utci: NaN };
+  }
+
   let kwargs;
   let ret;
   if (units.toLowerCase() == "ip") {
@@ -125,6 +133,7 @@ export function utci(
  * @returns {string}
  */
 function mapping(val) {
+  if (!isFinite(val)) return NaN;
   let left = 0;
   let right = stress_categories_vals.length - 1;
 

--- a/src/models/vertical_tmp_grad_ppd.js
+++ b/src/models/vertical_tmp_grad_ppd.js
@@ -4,6 +4,7 @@ import {
   round,
   units_converter,
 } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * @typedef {Object} VerTmpGradReturnType - a result set containing the predicted precentage of dissatisfied and the acceptability
@@ -58,6 +59,10 @@ export function vertical_tmp_grad_ppd(
   vertical_tmp_grad,
   units = "SI",
 ) {
+  if (!allValidNumbers(tdb, tr, vr, rh, met, clo, vertical_tmp_grad)) {
+    return { ppd_vg: NaN, acceptability: false };
+  }
+
   if (units === "IP") {
     ({
       tdb: tdb,

--- a/src/models/wbgt.js
+++ b/src/models/wbgt.js
@@ -1,4 +1,8 @@
 import { round } from "../utilities/utilities.js";
+import {
+  allValidNumbers,
+  isValidNumber,
+} from "../utilities/validate_inputs.js";
 
 const optionDefaults = {
   round: true,
@@ -59,6 +63,16 @@ const optionDefaults = {
  */
 export function wbgt(twb, tg, options) {
   const opt = Object.assign({}, optionDefaults, options);
+
+  if (
+    !allValidNumbers(twb, tg) ||
+    (opt.tdb !== undefined && !isValidNumber(opt.tdb))
+  ) {
+    if (opt.round) {
+      return NaN;
+    }
+    return { wbgt: NaN };
+  }
 
   let t_wbg;
 

--- a/src/models/wc.js
+++ b/src/models/wc.js
@@ -1,4 +1,5 @@
 import { round } from "../utilities/utilities.js";
+import { allValidNumbers } from "../utilities/validate_inputs.js";
 
 /**
  * Calculates the Wind Chill Index (WCI) in accordance with the ASHRAE 2017 Handbook Fundamentals - Chapter 9 {@link #ref_18|[18]}.
@@ -24,6 +25,10 @@ import { round } from "../utilities/utilities.js";
  * @returns {{wci: number}} wind chill index, [W/m2]
  */
 export function wc(tdb, v, kwargs = { round: true }) {
+  if (!allValidNumbers(tdb, v)) {
+    return { wci: NaN };
+  }
+
   let wci = (10.45 + 10 * Math.pow(v, 0.5) - v) * (33 - tdb);
   // the factor 1.163 is used to convert to W/m2
   wci = wci * 1.163;

--- a/src/utilities/validate_inputs.js
+++ b/src/utilities/validate_inputs.js
@@ -1,0 +1,26 @@
+/**
+ * Checks whether a value is a valid finite number.
+ *
+ * Rejects non-number types, NaN, and Infinity. Used as an input-validation
+ * guard at the entry of model functions so callers receive a predictable
+ * NaN-shaped result instead of propagating unexpected values through the
+ * calculation.
+ *
+ * @public
+ * @param {unknown} value - value to check
+ * @returns {boolean} true if value is a finite number
+ */
+export function isValidNumber(value) {
+  return typeof value === "number" && isFinite(value);
+}
+
+/**
+ * Checks whether every provided value is a valid finite number.
+ *
+ * @public
+ * @param {...unknown} values - values to check
+ * @returns {boolean} true if every value satisfies {@link isValidNumber}
+ */
+export function allValidNumbers(...values) {
+  return values.every(isValidNumber);
+}

--- a/src/utilities/validate_inputs.js
+++ b/src/utilities/validate_inputs.js
@@ -7,6 +7,7 @@
  * calculation.
  *
  * @public
+ * @ignore
  * @param {unknown} value - value to check
  * @returns {boolean} true if value is a finite number
  */
@@ -18,6 +19,7 @@ export function isValidNumber(value) {
  * Checks whether every provided value is a valid finite number.
  *
  * @public
+ * @ignore
  * @param {...unknown} values - values to check
  * @returns {boolean} true if every value satisfies {@link isValidNumber}
  */

--- a/tests/models/a_pmv.test.js
+++ b/tests/models/a_pmv.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { a_pmv } from "../../src/models/a_pmv.js";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Use the utils
@@ -20,5 +20,38 @@ describe("a_pmv", () => {
     const modelResult = a_pmv(tdb, tr, vr, rh, met, clo, a_coefficient, wme);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("a_pmv invalid input", () => {
+  const valid = {
+    tdb: 25,
+    tr: 25,
+    vr: 0.1,
+    rh: 50,
+    met: 1.2,
+    clo: 0.5,
+    a_coefficient: 0.293,
+  };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+    ["a_coefficient", { ...valid, a_coefficient: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = a_pmv(
+      args.tdb,
+      args.tr,
+      args.vr,
+      args.rh,
+      args.met,
+      args.clo,
+      args.a_coefficient,
+    );
+    expect(result.a_pmv).toBeNaN();
   });
 });

--- a/tests/models/adaptive_ashrae.test.js
+++ b/tests/models/adaptive_ashrae.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { adaptive_ashrae } from "../../src/models/adaptive_ashrae";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils";
@@ -65,5 +65,25 @@ describe("adaptive_ashrae scalar tests (hardcoded)", () => {
     validateResult(result, { tmp_cmf: 75.2 }, tolerances, {});
     expect(result.acceptability_80).toBe(true);
     expect(result.acceptability_90).toBe(true);
+  });
+});
+
+describe("adaptive_ashrae invalid input", () => {
+  const valid = { tdb: 25, tr: 25, t_running_mean: 20, v: 0.1 };
+
+  test.each([
+    ["tdb (undefined)", { ...valid, tdb: undefined }],
+    ["tr (string)", { ...valid, tr: "string" }],
+    ["t_running_mean (null)", { ...valid, t_running_mean: null }],
+    ["v (NaN)", { ...valid, v: NaN }],
+    ["tdb (Infinity)", { ...valid, tdb: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = adaptive_ashrae(
+      args.tdb,
+      args.tr,
+      args.t_running_mean,
+      args.v,
+    );
+    expect(result.tmp_cmf).toBeNaN();
   });
 });

--- a/tests/models/adaptive_en.test.js
+++ b/tests/models/adaptive_en.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { adaptive_en } from "../../src/models/adaptive_en";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // use the utils
@@ -70,5 +70,20 @@ describe("adaptive_en scalar tests (hardcoded)", () => {
     expect(result.acceptability_cat_i).toBe(true);
     expect(result.acceptability_cat_ii).toBe(true);
     expect(result.acceptability_cat_iii).toBe(true);
+  });
+});
+
+describe("adaptive_en invalid input", () => {
+  const valid = { tdb: 25, tr: 25, t_running_mean: 20, v: 0.1 };
+
+  test.each([
+    ["tdb (undefined)", { ...valid, tdb: undefined }],
+    ["tr (string)", { ...valid, tr: "string" }],
+    ["t_running_mean (null)", { ...valid, t_running_mean: null }],
+    ["v (NaN)", { ...valid, v: NaN }],
+    ["tdb (Infinity)", { ...valid, tdb: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = adaptive_en(args.tdb, args.tr, args.t_running_mean, args.v);
+    expect(result.tmp_cmf).toBeNaN();
   });
 });

--- a/tests/models/ankle_draft.test.js
+++ b/tests/models/ankle_draft.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { ankle_draft } from "../../src/models/ankle_draft.js";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,38 @@ describe("ankle_draft", () => {
     const modelResult = ankle_draft(tdb, tr, vr, rh, met, clo, v_ankle, units);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("ankle_draft invalid input", () => {
+  const valid = {
+    tdb: 25,
+    tr: 25,
+    vr: 0.2,
+    rh: 50,
+    met: 1.2,
+    clo: 0.5,
+    v_ankle: 0.1,
+  };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+    ["v_ankle", { ...valid, v_ankle: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = ankle_draft(
+      args.tdb,
+      args.tr,
+      args.vr,
+      args.rh,
+      args.met,
+      args.clo,
+      args.v_ankle,
+    );
+    expect(result.ppd_ad).toBeNaN();
   });
 });

--- a/tests/models/at.test.js
+++ b/tests/models/at.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { at } from "../../src/models/at.js";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -15,5 +15,20 @@ describe("at", () => {
     const modelResult = at(tdb, rh, v, q);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("at invalid input", () => {
+  const valid = { tdb: 25, rh: 30, v: 0.1 };
+
+  test.each([
+    ["tdb (undefined)", { ...valid, tdb: undefined }],
+    ["rh (string)", { ...valid, rh: "string" }],
+    ["v (null)", { ...valid, v: null }],
+    ["tdb (NaN)", { ...valid, tdb: NaN }],
+    ["rh (Infinity)", { ...valid, rh: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = at(args.tdb, args.rh, args.v);
+    expect(result.at).toBeNaN();
   });
 });

--- a/tests/models/athb.test.js
+++ b/tests/models/athb.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect } from "@jest/globals";
 import { athb } from "../../src/models/athb.js";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,34 @@ describe("athb", () => {
     const modelResult = athb(tdb, tr, vr, rh, met, t_running_mean);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("athb invalid input", () => {
+  const valid = {
+    tdb: 25,
+    tr: 25,
+    vr: 0.1,
+    rh: 50,
+    met: 1.1,
+    t_running_mean: 20,
+  };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = athb(
+      args.tdb,
+      args.tr,
+      args.vr,
+      args.rh,
+      args.met,
+      args.t_running_mean,
+    );
+    expect(result.athb_pmv).toBeNaN();
   });
 });

--- a/tests/models/clo_tout.test.js
+++ b/tests/models/clo_tout.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect } from "@jest/globals";
 import { clo_tout } from "../../src/models/clo_tout";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils";
@@ -18,5 +18,20 @@ describe("clo_tout", () => {
     const modelResult = clo_tout(tout, units);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("clo_tout invalid input", () => {
+  const valid = { tout: 25 };
+
+  test.each([
+    ["tout (undefined)", { ...valid, tout: undefined }],
+    ["tout (string)", { ...valid, tout: "string" }],
+    ["tout (null)", { ...valid, tout: null }],
+    ["tout (NaN)", { ...valid, tout: NaN }],
+    ["tout (Infinity)", { ...valid, tout: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = clo_tout(args.tout);
+    expect(result.clo_tout).toBeNaN();
   });
 });

--- a/tests/models/cooling_effect.test.js
+++ b/tests/models/cooling_effect.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect } from "@jest/globals";
 import { cooling_effect } from "../../src/models/cooling_effect";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
@@ -18,5 +18,28 @@ describe("cooling_effect", () => {
     const modelResult = cooling_effect(tdb, tr, vr, rh, met, clo, wme, units);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("cooling_effect invalid input", () => {
+  const valid = { tdb: 25, tr: 25, vr: 0.5, rh: 50, met: 1.2, clo: 0.5 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = cooling_effect(
+      args.tdb,
+      args.tr,
+      args.vr,
+      args.rh,
+      args.met,
+      args.clo,
+    );
+    expect(result.ce).toBeNaN();
   });
 });

--- a/tests/models/discomfort_index.test.js
+++ b/tests/models/discomfort_index.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect } from "@jest/globals";
 import { discomfort_index } from "../../src/models/discomfort_index";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,20 @@ describe("discomfort_index", () => {
     const modelResult = discomfort_index(tdb, rh);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("discomfort_index invalid input", () => {
+  const valid = { tdb: 25, rh: 50 };
+
+  test.each([
+    ["tdb (undefined)", { ...valid, tdb: undefined }],
+    ["rh (string)", { ...valid, rh: "string" }],
+    ["tdb (null)", { ...valid, tdb: null }],
+    ["rh (NaN)", { ...valid, rh: NaN }],
+    ["tdb (Infinity)", { ...valid, tdb: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = discomfort_index(args.tdb, args.rh);
+    expect(result.di).toBeNaN();
   });
 });

--- a/tests/models/e_pmv.test.js
+++ b/tests/models/e_pmv.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { e_pmv } from "../../src/models/e_pmv";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,38 @@ describe("e_pmv", () => {
     const modelResult = e_pmv(tdb, tr, vr, rh, met, clo, e_coefficient);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("e_pmv invalid input", () => {
+  const valid = {
+    tdb: 25,
+    tr: 25,
+    vr: 0.1,
+    rh: 50,
+    met: 1.2,
+    clo: 0.5,
+    e_coefficient: 0.6,
+  };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+    ["e_coefficient", { ...valid, e_coefficient: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = e_pmv(
+      args.tdb,
+      args.tr,
+      args.vr,
+      args.rh,
+      args.met,
+      args.clo,
+      args.e_coefficient,
+    );
+    expect(result.e_pmv).toBeNaN();
   });
 });

--- a/tests/models/heat_index.test.js
+++ b/tests/models/heat_index.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { heat_index } from "../../src/models/heat_index";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,20 @@ describe("heat_index", () => {
     const modelResult = heat_index(tdb, rh, options);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("heat_index invalid input", () => {
+  const valid = { tdb: 30, rh: 80 };
+
+  test.each([
+    ["tdb=undefined", { ...valid, tdb: undefined }],
+    ["rh='string'", { ...valid, rh: "string" }],
+    ["tdb=null", { ...valid, tdb: null }],
+    ["rh=NaN", { ...valid, rh: NaN }],
+    ["tdb=Infinity", { ...valid, tdb: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = heat_index(args.tdb, args.rh);
+    expect(result.hi).toBeNaN();
   });
 });

--- a/tests/models/humidex.test.js
+++ b/tests/models/humidex.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { humidex } from "../../src/models/humidex";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,20 @@ describe("humidex", () => {
     const modelResult = humidex(tdb, rh, options);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("humidex invalid input", () => {
+  const valid = { tdb: 25, rh: 50 };
+
+  test.each([
+    ["tdb=undefined", { ...valid, tdb: undefined }],
+    ["rh='string'", { ...valid, rh: "string" }],
+    ["tdb=null", { ...valid, tdb: null }],
+    ["rh=NaN", { ...valid, rh: NaN }],
+    ["tdb=Infinity", { ...valid, tdb: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = humidex(args.tdb, args.rh);
+    expect(result.humidex).toBeNaN();
   });
 });

--- a/tests/models/net.test.js
+++ b/tests/models/net.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { net } from "../../src/models/net";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,20 @@ describe("net", () => {
     const modelResult = net(tdb, rh, v, options);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("net invalid input", () => {
+  const valid = { tdb: 37, rh: 100, v: 3.5 };
+
+  test.each([
+    ["tdb=undefined", { ...valid, tdb: undefined }],
+    ["rh='string'", { ...valid, rh: "string" }],
+    ["v=null", { ...valid, v: null }],
+    ["tdb=NaN", { ...valid, tdb: NaN }],
+    ["rh=Infinity", { ...valid, rh: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = net(args.tdb, args.rh, args.v);
+    expect(result.net).toBeNaN();
   });
 });

--- a/tests/models/pet_steady.test.js
+++ b/tests/models/pet_steady.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { pet_steady } from "../../src/models/pet_steady";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
@@ -18,5 +18,27 @@ describe("pet_steady", () => {
     const modelResult = pet_steady(tdb, tr, v, rh, met, clo);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("pet_steady invalid input", () => {
+  const valid = { tdb: 20, tr: 20, v: 0.3, rh: 50, met: 1.37, clo: 0.5 };
+
+  test.each([
+    ["tdb=undefined", { ...valid, tdb: undefined }],
+    ["tr='string'", { ...valid, tr: "string" }],
+    ["v=null", { ...valid, v: null }],
+    ["rh=NaN", { ...valid, rh: NaN }],
+    ["met=Infinity", { ...valid, met: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = pet_steady(
+      args.tdb,
+      args.tr,
+      args.v,
+      args.rh,
+      args.met,
+      args.clo,
+    );
+    expect(result.pet).toBeNaN();
   });
 });

--- a/tests/models/phs.test.js
+++ b/tests/models/phs.test.js
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
+import { beforeAll, describe, expect, it, test } from "@jest/globals";
 import fetch from "node-fetch";
 import { phs } from "../../src/models/phs";
 import { testDataUrls } from "./comftest"; // Import test URLs from comftest.js
@@ -89,5 +89,37 @@ describe("phs", () => {
         throw error; // Re-throw to display specific error details
       }
     });
+  });
+});
+
+describe("phs invalid input", () => {
+  const valid = {
+    tdb: 40,
+    tr: 40,
+    v: 0.3,
+    rh: 35,
+    met: 150,
+    clo: 0.5,
+    posture: 2,
+  };
+
+  test.each([
+    ["tdb=undefined", { ...valid, tdb: undefined }],
+    ["tr='string'", { ...valid, tr: "string" }],
+    ["v=null", { ...valid, v: null }],
+    ["rh=NaN", { ...valid, rh: NaN }],
+    ["met=Infinity", { ...valid, met: Infinity }],
+    ["clo=undefined", { ...valid, clo: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = phs(
+      args.tdb,
+      args.tr,
+      args.v,
+      args.rh,
+      args.met,
+      args.clo,
+      args.posture,
+    );
+    expect(result.t_re).toBeNaN();
   });
 });

--- a/tests/models/pmv.test.js
+++ b/tests/models/pmv.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { pmv } from "../../src/models/pmv.js";
 import { validateResult } from "./testUtils.js";
 
@@ -27,5 +27,21 @@ describe("pmv", () => {
     const modelResult = { pmv: pmv(tdb, tr, vr, rh, met, clo, wme, standard) };
 
     validateResult(modelResult, outputs, tolerances, inputs);
+  });
+});
+
+describe("pmv invalid input", () => {
+  const valid = { tdb: 25, tr: 25, vr: 0.1, rh: 50, met: 1.2, clo: 0.5 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = pmv(args.tdb, args.tr, args.vr, args.rh, args.met, args.clo);
+    expect(result).toBeNaN();
   });
 });

--- a/tests/models/pmv_ppd.test.js
+++ b/tests/models/pmv_ppd.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { pmv_ppd } from "../../src/models/pmv_ppd.js";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils.js";
@@ -47,5 +47,28 @@ describe("pmv_pdd", () => {
     );
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("pmv_ppd invalid input", () => {
+  const valid = { tdb: 25, tr: 25, vr: 0.1, rh: 50, met: 1.2, clo: 0.5 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = pmv_ppd(
+      args.tdb,
+      args.tr,
+      args.vr,
+      args.rh,
+      args.met,
+      args.clo,
+    );
+    expect(result.pmv).toBeNaN();
   });
 });

--- a/tests/models/set_tmp.test.js
+++ b/tests/models/set_tmp.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { set_tmp } from "../../src/models/set_tmp";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Use modular utilities to load data and check if test should be skipped
@@ -53,5 +53,28 @@ describe("set_tmp", () => {
     );
 
     validateResult(modelResult, outputs, tolerances, inputs);
+  });
+});
+
+describe("set_tmp invalid input", () => {
+  const valid = { tdb: 25, tr: 25, v: 0.1, rh: 50, met: 1.2, clo: 0.5 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["v", { ...valid, v: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = set_tmp(
+      args.tdb,
+      args.tr,
+      args.v,
+      args.rh,
+      args.met,
+      args.clo,
+    );
+    expect(result.set).toBeNaN();
   });
 });

--- a/tests/models/solar_gain.test.js
+++ b/tests/models/solar_gain.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { solar_gain } from "../../src/models/solar_gain";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils";
@@ -36,5 +36,34 @@ describe("solar_gain", () => {
     );
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("solar_gain invalid input", () => {
+  const valid = {
+    sol_altitude: 0,
+    sharp: 120,
+    sol_radiation_dir: 800,
+    sol_transmittance: 0.5,
+    f_svv: 0.5,
+    f_bes: 0.5,
+  };
+
+  test.each([
+    ["sol_altitude", { ...valid, sol_altitude: undefined }],
+    ["sharp", { ...valid, sharp: "string" }],
+    ["sol_radiation_dir", { ...valid, sol_radiation_dir: null }],
+    ["sol_transmittance", { ...valid, sol_transmittance: NaN }],
+    ["f_svv", { ...valid, f_svv: Infinity }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = solar_gain(
+      args.sol_altitude,
+      args.sharp,
+      args.sol_radiation_dir,
+      args.sol_transmittance,
+      args.f_svv,
+      args.f_bes,
+    );
+    expect(result.erf).toBeNaN();
   });
 });

--- a/tests/models/two_nodes.test.js
+++ b/tests/models/two_nodes.test.js
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
+import { beforeAll, describe, expect, it, test } from "@jest/globals";
 import { loadTestData } from "./testUtils";
 import { two_nodes } from "../../src/models/two_nodes";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
@@ -100,5 +100,28 @@ describe("two_nodes validation logic (Testing the Test)", () => {
         );
       }
     }).not.toThrow();
+  });
+});
+
+describe("two_nodes invalid input", () => {
+  const valid = { tdb: 25, tr: 25, v: 0.1, rh: 50, met: 1.2, clo: 0.5 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["v", { ...valid, v: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+  ])("returns NaN result when %s is invalid", (_label, args) => {
+    const result = two_nodes(
+      args.tdb,
+      args.tr,
+      args.v,
+      args.rh,
+      args.met,
+      args.clo,
+    );
+    expect(result.set).toBeNaN();
   });
 });

--- a/tests/models/use_fans_heatwave.test.js
+++ b/tests/models/use_fans_heatwave.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { use_fans_heatwaves } from "../../src/models/use_fans_heatwave";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 import { loadTestData, validateResult } from "./testUtils";
@@ -47,5 +47,28 @@ describe("use_fans_heatwaves", () => {
     );
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("use_fans_heatwaves invalid input", () => {
+  const valid = { tdb: 25, tr: 25, v: 0.1, rh: 50, met: 1.2, clo: 0.5 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["v", { ...valid, v: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+  ])("returns NaN when %s is invalid", (_label, args) => {
+    const result = use_fans_heatwaves(
+      args.tdb,
+      args.tr,
+      args.v,
+      args.rh,
+      args.met,
+      args.clo,
+    );
+    expect(result.e_skin).toBeNaN();
   });
 });

--- a/tests/models/utci.test.js
+++ b/tests/models/utci.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { utci } from "../../src/models/utci.js";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
@@ -20,5 +20,20 @@ describe("utci", () => {
     const modelResult = utci(tdb, tr, v, rh, units, return_stress_category);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("utci invalid input", () => {
+  const valid = { tdb: 25, tr: 25, v: 0.5, rh: 50 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["v", { ...valid, v: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["tdb", { ...valid, tdb: Infinity }],
+  ])("returns NaN when %s is invalid", (_label, args) => {
+    const result = utci(args.tdb, args.tr, args.v, args.rh);
+    expect(result.utci).toBeNaN();
   });
 });

--- a/tests/models/vertical_tmp_grad_ppd.test.js
+++ b/tests/models/vertical_tmp_grad_ppd.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { vertical_tmp_grad_ppd } from "../../src/models/vertical_tmp_grad_ppd";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
@@ -27,5 +27,38 @@ describe("vertical_tmp_grad_ppd", () => {
     );
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("vertical_tmp_grad_ppd invalid input", () => {
+  const valid = {
+    tdb: 25,
+    tr: 25,
+    vr: 0.1,
+    rh: 50,
+    met: 1.2,
+    clo: 0.5,
+    vertical_tmp_grad: 5,
+  };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["tr", { ...valid, tr: "string" }],
+    ["vr", { ...valid, vr: null }],
+    ["rh", { ...valid, rh: NaN }],
+    ["met", { ...valid, met: Infinity }],
+    ["clo", { ...valid, clo: undefined }],
+    ["vertical_tmp_grad", { ...valid, vertical_tmp_grad: undefined }],
+  ])("returns NaN when %s is invalid", (_label, args) => {
+    const result = vertical_tmp_grad_ppd(
+      args.tdb,
+      args.tr,
+      args.vr,
+      args.rh,
+      args.met,
+      args.clo,
+      args.vertical_tmp_grad,
+    );
+    expect(result.ppd_vg).toBeNaN();
   });
 });

--- a/tests/models/wbgt.test.js
+++ b/tests/models/wbgt.test.js
@@ -29,3 +29,33 @@ describe("wbgt", () => {
     }
   });
 });
+
+describe("wbgt invalid input", () => {
+  const valid = { twb: 25, tg: 32 };
+
+  describe("with round=true (default)", () => {
+    test.each([
+      ["twb", { ...valid, twb: undefined }],
+      ["tg", { ...valid, tg: "string" }],
+      ["twb", { ...valid, twb: null }],
+      ["tg", { ...valid, tg: NaN }],
+      ["twb", { ...valid, twb: Infinity }],
+    ])("returns NaN when %s is invalid", (_label, args) => {
+      const result = wbgt(args.twb, args.tg);
+      expect(result).toBeNaN();
+    });
+  });
+
+  describe("with round=false", () => {
+    test.each([
+      ["twb", { ...valid, twb: undefined }],
+      ["tg", { ...valid, tg: "string" }],
+      ["twb", { ...valid, twb: null }],
+      ["tg", { ...valid, tg: NaN }],
+      ["twb", { ...valid, twb: Infinity }],
+    ])("returns NaN object when %s is invalid", (_label, args) => {
+      const result = wbgt(args.twb, args.tg, { round: false });
+      expect(result.wbgt).toBeNaN();
+    });
+  });
+});

--- a/tests/models/wc.test.js
+++ b/tests/models/wc.test.js
@@ -1,4 +1,4 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { wc } from "../../src/models/wc.js";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
@@ -16,5 +16,20 @@ describe("test_wc", () => {
     const modelResult = wc(tdb, v, kwargs);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("wc invalid input", () => {
+  const valid = { tdb: -5, v: 5 };
+
+  test.each([
+    ["tdb", { ...valid, tdb: undefined }],
+    ["v", { ...valid, v: "string" }],
+    ["tdb", { ...valid, tdb: null }],
+    ["v", { ...valid, v: NaN }],
+    ["tdb", { ...valid, tdb: Infinity }],
+  ])("returns NaN when %s is invalid", (_label, args) => {
+    const result = wc(args.tdb, args.v);
+    expect(result.wci).toBeNaN();
   });
 });


### PR DESCRIPTION
Adds numeric input validation to 25 model functions (out of 28 total exports). Each function now checks that numeric parameters are finite numbers before calculating. Invalid inputs (undefined, null, strings, NaN, Infinity) trigger an early return with NaN in the same shape the function normally uses — most return an object like { pmv: NaN, ppd: NaN }, but pmv and wbgt (round=true) return bare NaN directly. The three not touched are JOS3 (class, out of scope), pmv_ppd_ashrae and pmv_ppd_iso (thin wrappers — their inputs get validated when they call pmv_ppd internally).

Ref #142. This covers type validation only. I left range validation (limit_inputs boundaries like 10 ≤ tdb < 40 for PMV per ASHRAE 55) for a follow-up PR — need to map out the pythermalcomfort ranges properly first.

Implementation: a small utility src/utilities/validate_inputs.js with isValidNumber (typeof === 'number' && isFinite) and allValidNumbers. Each model calls the guard at the top. No calculation logic changed.

Also fixed two things I noticed along the way:
- utci mapping() was returning a stress category string for NaN input; added an isFinite guard so it returns NaN instead
- adaptive_en JSDoc example showed true for acceptability when t_running_mean = 9 (out of range), corrected to false

Both helpers are tagged @ignore to keep them out of the generated docs.

Every model has parametrised invalid-input tests covering each numeric parameter with all five bad-value types. Models with extra validated params (clo, v_ankle, a_coefficient, etc.) have dedicated rows. wbgt has separate sub-blocks for round=true and round=false. 68 suites, 2012 tests, 0 failures.

This PR does not add checks for most boolean/enum parameters (units, limit_inputs, round, standard). phs posture is a special case — it accepts both numbers and strings, so it has a dedicated type check alongside the numeric guard.