### PR TITLE
ci: automate GitHub Release creation alongside NPM publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,6 @@ jobs:
       - run: npm publish --provenance
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: checks
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
@@ -51,3 +51,8 @@ jobs:
 
       - run: npm ci
       - run: npm publish --provenance
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/docs_theme/contributing.md
+++ b/docs_theme/contributing.md
@@ -218,4 +218,6 @@ Releases are published from Git tags by GitHub Actions. Local builds are not req
    ```
 4. Pushing a `v*` tag (for example `v1.0.3`) triggers the publish workflow.
 
-The publish workflow runs checks (`npm run check:format`, `npm test`, `npm run build`) and then runs `npm publish` in CI.
+The publish workflow runs checks (`npm run check:format`, `npm test`, `npm run build`) and then automatically:
+- Runs `npm publish` to publish the package to the NPM registry.
+- Creates a new GitHub Release with automatically generated release notes based on merged PRs.


### PR DESCRIPTION
Currently, our GitHub Actions workflow automatically publishes a new package to the NPM registry whenever a new v* tag is pushed. However, this does not automatically create a Release on our GitHub repository. This has led to our GitHub Releases page becoming outdated which can confuse users looking for the latest version.

---

### What was changed:

- Added explicit `contents: write` permissions and implemented the `softprops/action-gh-release` step in `.github/workflows/publish.yml`.
- Updated docs_theme/contributing.md to reflect the new release workflow.

Pushing a new v* tag will now automatically trigger both an NPM publish and the creation of a new GitHub Release. The release will automatically generate its own release notes (changelog) based on the PRs merged since the last tag. 