### PR TITLE
fix(deps): bump mathjs to ^15.2.0 (addresses #148)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "mathjs": "^11.12.0",
+        "mathjs": "^15.2.0",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
@@ -1351,9 +1351,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1748,15 +1748,16 @@
       }
     },
     "node_modules/complex.js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.1.tgz",
-      "integrity": "sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.4.3.tgz",
+      "integrity": "sha512-UrQVSUur14tNX6tiP4y8T4w4FeJAX3bi2cIv0pu/DTLFNxoq7z2Yh83Vfzztj6Px3X/lubqQ9IrPp7Bpn6p4MQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/concat-map": {
@@ -1997,9 +1998,9 @@
       "dev": true
     },
     "node_modules/documentation/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2340,14 +2341,15 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.4.tgz",
-      "integrity": "sha512-pwiTgt0Q7t+GHZA4yaLjObx4vXmmdcS0iSJ19o8d/goUGgItX9UZWKWNnLHehxviD8wU2IWRsnR8cD5+yOJP2Q==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
-        "type": "patreon",
+        "type": "github",
         "url": "https://github.com/sponsors/rawify"
       }
     },
@@ -3985,9 +3987,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4282,26 +4284,26 @@
       }
     },
     "node_modules/mathjs": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.12.0.tgz",
-      "integrity": "sha512-UGhVw8rS1AyedyI55DGz9q1qZ0p98kyKPyc9vherBkoueLntPfKtPBh14x+V4cdUWK0NZV2TBwqRFlvadscSuw==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-15.2.0.tgz",
+      "integrity": "sha512-UAQzSVob9rNLdGpqcFMYmSu9dkuLYy7Lr2hBEQS5SHQdknA9VppJz3cy2KkpMzTODunad6V6cNv+5kOLsePLow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "complex.js": "^2.1.1",
+        "@babel/runtime": "^7.26.10",
+        "complex.js": "^2.2.5",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",
-        "fraction.js": "4.3.4",
+        "fraction.js": "^5.2.1",
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.1.1"
+        "typed-function": "^4.2.1"
       },
       "bin": {
         "mathjs": "bin/cli.js"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -5591,10 +5593,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -6571,11 +6574,12 @@
       }
     },
     "node_modules/typed-function": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
-      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.2.2.tgz",
+      "integrity": "sha512-VwaXim9Gp1bngi/q3do8hgttYn2uC3MoT/gfuMWylnj1IeZBUAyPddHZlo1K05BDoj8DYPpMdiHqH1dDYdJf2A==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "mathjs": "^11.12.0",
+    "mathjs": "^15.2.0",
     "node-fetch": "^3.3.2"
   }
 }


### PR DESCRIPTION
Bumps `mathjs` to `^15.2.0` to close the Snyk advisory (SNYK-JS-MATHJS-15989794).

I went through the v12–v15 release notes against the `math.*` calls used in `src/`. Nothing there affects the APIs this codebase actually uses, and the full Jest suite (68 suites, 1867 tests) passes unchanged on 15.2.0; `check:format` and `build` are green.

Per the issue's ask to also check other dependencies, I ran targeted `npm update` for three packages with pre-existing advisories: `lodash` `^4.17.23` → `4.18.1` (HIGH), `picomatch` `2.3.1` → `2.3.2` (HIGH, transitive via jest / lint-staged / micromatch), and `brace-expansion` (MODERATE, transitive via minimatch). Each stays within its existing semver range.

One advisory chain is left: `vue-template-compiler` (GHSA-g3ch-rx76-35fx), which is an `optionalDependencies` of `documentation@14`. Both packages show up in `npm audit` but it's the same underlying issue. I couldn't find a clean fix. `documentation` hasn't shipped since 14.0.3 in 2024-01-30, `npm audit fix` only offers a major downgrade to v6 (which breaks the ESM theme loader), Vue 2 is EOL so there's no patched 2.x to override to, and an `overrides` alias for `vue-template-compiler` didn't clear the audit either. In any case this project only documents plain JS sources, so the actual vulnerable path in `documentation` (its `.vue` file handling) isn't reached here. Can do as a separate PR if you want.

`npm audit`: 5 advisories (2 high, 3 moderate) → 2 (0 high, 2 moderate). Only `package.json` and `package-lock.json` are changed.

Closes #148.
