### PR TITLE
fix: move 1.4 multiplier outside fourth root in ISO t_mrt()

### DIFF
--- a/src/psychrometrics/t_mrt.js
+++ b/src/psychrometrics/t_mrt.js
@@ -87,7 +87,7 @@ function get_tr_iso(_tg, _tdb, _v, _d, _emissivity) {
   _tdb += c_to_k;
 
   // calculate heat transfer coefficient
-  const h_n = Math.pow(1.4 * (Math.abs(_tg - _tdb) / _d), 0.25); // natural convection
+  const h_n = 1.4 * Math.pow(Math.abs(_tg - _tdb) / _d, 0.25); // natural convection
   const h_f = (6.3 * Math.pow(_v, 0.6)) / Math.pow(_d, 0.4); // forced convection
 
   // get the biggest between the two coefficients

--- a/tests/psychrometrics/t_mrt.test.js
+++ b/tests/psychrometrics/t_mrt.test.js
@@ -12,6 +12,18 @@ describe("t_mrt", () => {
       standard: "ISO",
       expected: 74.8,
     },
+    // Low-wind ISO case: natural convection dominates, so a bug in the
+    // 1.4 coefficient of h_n surfaces here. The high-wind case above
+    // sits in the forced-convection regime and is insensitive to it.
+    {
+      tg: 20,
+      tdb: 10,
+      v: 0.1,
+      d: 0.05,
+      emissivity: 0.95,
+      standard: "ISO",
+      expected: 29.3,
+    },
     {
       tg: 25.42,
       tdb: 26.1,


### PR DESCRIPTION
Fixes #128.

`get_tr_iso()` had the ISO natural-convection term as `Math.pow(1.4 * Math.abs(tg - tdb) / d, 0.25)` instead of `1.4 * Math.pow(Math.abs(tg - tdb) / d, 0.25)`. Ports the upstream fix from pythermalcomfort commit [3b4b625](https://github.com/CenterForTheBuiltEnvironment/pythermalcomfort/commit/3b4b625), released in 3.9.1.

I added a low-wind regression case (`tg=20, tdb=10, v=0.1, d=0.05`) that rounds to `29.3`. The existing `tg=53.2, v=0.3` case is forced-convection-dominated, so it didn't catch this. Reference computed from `pythermalcomfort.utilities.mean_radiant_tmp()` in 3.9.1; `validation-data-comfort-models` doesn't carry a `t_mrt` table.
