### PR TITLE
test(two_nodes): repair validation harness and expose row failures

### DIFF
--- a/tests/models/two_nodes.test.js
+++ b/tests/models/two_nodes.test.js
@@ -1,73 +1,89 @@
-import { expect, describe, it, beforeAll } from "@jest/globals";
-import { loadTestData } from "./testUtils";
+import { expect, describe, test, it } from "@jest/globals";
+import { loadTestData, validateResult } from "./testUtils";
 import { two_nodes } from "../../src/models/two_nodes";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 
 // Use the URL from comftest.js to fetch data for two_nodes tests
 const testDataUrl = testDataUrls.twoNodes; // Ensure the correct URL is added in comftest.js
 
-let testData;
-let tolerance;
+// Load data at module scope so test.each can register one test per row.
+const { testData, tolerances } = await loadTestData(testDataUrl, false);
 
-// Load data before tests
-beforeAll(async () => {
-  const result = await loadTestData(testDataUrl, "twoNodes"); // Load data from URL using loadTestData
-  testData = result.testData;
-  tolerance = result.tolerance || 0.1; // Set a default tolerance
-});
-
-// General test function to verify results for different test functions
-function runTest(testFunction, inputs, expected) {
-  const {
-    tdb,
-    tr,
-    v,
-    rh,
-    met,
-    clo,
-    wme,
-    body_surface_area,
-    p_atmospheric,
-    body_position,
-    max_skin_blood_flow,
-    kwargs,
-  } = inputs;
-
-  const result = testFunction(
-    tdb,
-    tr,
-    v,
-    rh,
-    met,
-    clo,
-    wme,
-    body_surface_area,
-    p_atmospheric,
-    body_position,
-    max_skin_blood_flow,
-    kwargs,
-  );
-
-  // Use specified tolerance or default to 0.0001
-  const tol = tolerance !== undefined ? tolerance : 0.0001;
-  expect(Math.abs(result - expected)).toBeLessThanOrEqual(tol);
-}
+// Skip rows with missing outputs or array-valued inputs; keep original
+// dataset index so failures are reported as "row N" matching the JSON file.
+const scalarRows = testData.data
+  .map((row, index) => ({ ...row, index }))
+  .filter(({ inputs, outputs }) => {
+    if (outputs === undefined || outputs === null) return false;
+    return !Object.values(inputs).some((value) => Array.isArray(value));
+  });
 
 describe("two_nodes related tests", () => {
-  it("should run two_nodes tests after data is loaded", () => {
-    if (!testData || !testData.data)
-      throw new Error("Test data is undefined or data not loaded");
+  test.each(scalarRows)("row $index", ({ inputs, outputs }) => {
+    const {
+      tdb,
+      tr,
+      v,
+      rh,
+      met,
+      clo,
+      wme,
+      body_surface_area,
+      p_atmospheric,
+      body_position,
+      max_skin_blood_flow,
+      kwargs,
+      w_max,
+      max_sweating,
+    } = inputs;
 
-    testData.data.forEach(({ inputs, expected }) => {
-      // Skip empty or invalid data
-      if (expected === undefined || expected === null) return;
+    const mergedKwargs = {
+      w_max,
+      max_sweating,
+      ...(kwargs ?? {}),
+      round: false,
+    };
+    for (const k of Object.keys(mergedKwargs)) {
+      if (mergedKwargs[k] === undefined) delete mergedKwargs[k];
+    }
 
-      // Skip array inputs — only test scalar cases
-      const values = Object.values(inputs);
-      if (values.some((value) => Array.isArray(value))) return;
+    const result = two_nodes(
+      tdb,
+      tr,
+      v,
+      rh,
+      met,
+      clo,
+      wme,
+      body_surface_area,
+      p_atmospheric,
+      body_position,
+      max_skin_blood_flow,
+      mergedKwargs,
+    );
 
-      runTest(two_nodes, inputs, expected);
-    });
+    const resultSnakeCase = {
+      disc: result.disc,
+      t_core: result.tCore,
+      e_skin: result.eSkin,
+      e_rsw: result.eRsw,
+      e_max: result.eMax,
+      q_sensible: result.qSensible,
+      q_skin: result.qSkin,
+      q_res: result.qRes,
+      t_skin: result.tSkin,
+      m_bl: result.mBl,
+      m_rsw: result.mRsw,
+      w: result.w,
+      w_max: result.wMax,
+      set: result.set,
+      et: result.et,
+      pmv_gagge: result.pmvGagge,
+      pmv_set: result.pmvSet,
+      t_sens: result.tSens,
+    };
+
+    validateResult(resultSnakeCase, outputs, tolerances, inputs);
   });
 });
 


### PR DESCRIPTION
Partial fix for #135.

Note: force-pushed this PR to drop commit `1714cfa5` (the `calculate_w_max` source fix). This branch now only changes `tests/models/two_nodes.test.js`; #145 is carrying the source fix.

The `two_nodes` test harness wasn't exercising the validation dataset. The main issue: the test destructured `{ inputs, expected }`, but `ts_two_nodes_gagge.json` stores results under `outputs`, so `expected` was always `undefined` and the per-row skip guard silently dropped all 10 dataset rows. The only real assertions running were the two meta-tests in the second `describe`.

Three more harness issues were hiding behind that (rows are 0-indexed to match the JSON array):

1. Flat override fields (`w_max`, `max_sweating`) sit at the top of `inputs` in the JSON, not nested under `inputs.kwargs`, so overrides in rows 6 and 8 were dropped by the harness. Row 5's `w_max: false` is the default-formula sentinel, so dropping it had no behavioural effect.
2. The harness didn't force `round: false`, so rows with 2-decimal reference values, like row 4's `w=0.17`, failed on a rounded `w=0.2`. `round: false` also switches output keys from snake_case to camelCase, so the harness now normalises the keys.
3. All rows ran inside a single `it(... forEach ...)`, which stopped at the first failure. This now uses `test.each` so every row reports independently.

Two plumbing fixes also rolled in: `loadTestData` was called with `"twoNodes"` as the second argument where the signature expects a boolean `returnArray`, and the return was destructured as `tolerance` where the helper returns `tolerances`.

Current result on this branch: the harness now runs all 10 dataset rows. `two_nodes.test.js` registers 12 Jest tests (10 rows + 2 meta-tests): 10 pass, 2 fail.

- Row 6 fails on `t_core`, `e_skin`, `m_rsw`, `t_skin`, `w`, `disc`, and `pmv_set`. The root cause is the `calculate_w_max` guard zeroing `w_max` on this branch, which cascades through the evaporative-sweat path (`w=0`, `m_rsw=0`, and so on). #145 should unblock Row 6; the residual `disc` mismatch is tracked in #152 but can only be isolated once the w_max cascade is gone.
- Row 7 fails on an `nSimulation` initial-value off-by-one, tracked in #153.

So this PR is test-harness only: it exposes the real validation failures but does not fix the model bugs. CI will stay partially red until #145, #152, and #153 land.