### PR TITLE
fix: classify UTCI stress categories by range, not nearest boundary

### DIFF
--- a/src/models/utci.js
+++ b/src/models/utci.js
@@ -23,10 +23,6 @@ const stress_categories = [
   "extreme heat stress",
 ];
 
-const stress_categories_vals = [
-  -40.0, -27.0, -13.0, 0.0, 9.0, 26, 32, 38, 46, 1000,
-];
-
 /**
  * Determines the Universal Thermal Climate Index (UTCI). The UTCI is the
     equivalent temperature for the environment derived from a reference
@@ -122,34 +118,21 @@ export function utci(
 /**
  * Maps a temperature to the stress category.
  * @param {number} val
- * @returns {string}
+ * @returns {string|number} Stress category label, or NaN for non-finite input.
  */
-function mapping(val) {
-  let left = 0;
-  let right = stress_categories_vals.length - 1;
-
-  while (right - left > 1) {
-    const mid = Math.floor((left + right) / 2);
-    if (stress_categories_vals[mid] === val) {
-      return stress_categories[mid];
-    } else if (stress_categories_vals[mid] < val) {
-      left = mid;
-    } else {
-      right = mid;
-    }
-  }
-  if (right === 0) {
-    return stress_categories[0];
-  }
-
-  if (
-    stress_categories_vals[right] - val >
-    val - stress_categories_vals[left]
-  ) {
-    return stress_categories[left];
-  } else {
-    return stress_categories[right];
-  }
+export function mapping(val) {
+  // Right-inclusive thresholds; matches pythermalcomfort np.digitize(right=True).
+  if (!Number.isFinite(val)) return NaN;
+  if (val <= -40) return stress_categories[0];
+  if (val <= -27) return stress_categories[1];
+  if (val <= -13) return stress_categories[2];
+  if (val <= 0) return stress_categories[3];
+  if (val <= 9) return stress_categories[4];
+  if (val <= 26) return stress_categories[5];
+  if (val <= 32) return stress_categories[6];
+  if (val <= 38) return stress_categories[7];
+  if (val <= 46) return stress_categories[8];
+  return stress_categories[9];
 }
 
 /**

--- a/tests/models/utci.test.js
+++ b/tests/models/utci.test.js
@@ -1,5 +1,5 @@
-import { describe } from "@jest/globals";
-import { utci } from "../../src/models/utci.js";
+import { describe, expect, test } from "@jest/globals";
+import { mapping, utci } from "../../src/models/utci.js";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 import { loadTestData, validateResult } from "./testUtils"; // Import utility functions
 
@@ -20,5 +20,73 @@ describe("utci", () => {
     const modelResult = utci(tdb, tr, v, rh, units, return_stress_category);
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+describe("mapping() stress category classification (Issue #147)", () => {
+  // Boundary values belong to the lower category (right-inclusive convention).
+  test.each([
+    // exact boundaries
+    [-40, "extreme cold stress"],
+    [-27, "very strong cold stress"],
+    [-13, "strong cold stress"],
+    [0, "moderate cold stress"],
+    [9, "slight cold stress"],
+    [26, "no thermal stress"],
+    [32, "moderate heat stress"],
+    [38, "strong heat stress"],
+    [46, "very strong heat stress"],
+    // bug-exposing inputs from the issue and real user reports
+    [15.2, "no thermal stress"],
+    [28.9, "moderate heat stress"],
+    [50, "extreme heat stress"],
+    // midpoint and out-of-range inputs
+    [-50, "extreme cold stress"],
+    [-100, "extreme cold stress"],
+    [-33.5, "very strong cold stress"],
+    [-20, "strong cold stress"],
+    [-6.5, "moderate cold stress"],
+    [4.5, "slight cold stress"],
+    [17.5, "no thermal stress"],
+    [29, "moderate heat stress"],
+    [35, "strong heat stress"],
+    [42, "very strong heat stress"],
+    [47, "extreme heat stress"],
+    [100, "extreme heat stress"],
+    [0.001, "slight cold stress"],
+  ])("UTCI %p should map to %p", (utciValue, expectedCategory) => {
+    expect(mapping(utciValue)).toBe(expectedCategory);
+  });
+
+  // just above each finite boundary bumps to the next category
+  test.each([
+    [-39.999, "very strong cold stress"],
+    [-26.999, "strong cold stress"],
+    [-12.999, "moderate cold stress"],
+    [0.0001, "slight cold stress"],
+    [9.0001, "no thermal stress"],
+    [26.0001, "moderate heat stress"],
+    [32.0001, "strong heat stress"],
+    [38.0001, "very strong heat stress"],
+    [46.0001, "extreme heat stress"],
+  ])("UTCI %p should map to %p", (utciValue, expectedCategory) => {
+    expect(mapping(utciValue)).toBe(expectedCategory);
+  });
+
+  test.each([[NaN], [Infinity], [-Infinity]])(
+    "UTCI %p should map to NaN",
+    (utciValue) => {
+      expect(mapping(utciValue)).toBeNaN();
+    },
+  );
+});
+
+describe("utci() stress_category with invalid inputs (Issue #147)", () => {
+  test("out-of-range inputs yield utci=NaN and stress_category=NaN", () => {
+    // tdb=51 is outside limit_inputs [-50, 50], so utci_approx becomes NaN;
+    // stress_category must propagate NaN instead of a misleading label.
+    const result = utci(51, 22, 16, 50, "SI", true);
+    expect(result.utci).toBeNaN();
+    expect(result.stress_category).toBeNaN();
   });
 });


### PR DESCRIPTION
## What this PR does

- Replace `mapping()` in `src/models/utci.js` with a `<=` threshold chain matching `np.digitize(right=True)`: boundary values belong to the lower category.
- Non-finite inputs (`NaN`, `±Infinity`) now return `NaN` so `stress_category` propagates alongside `utci` when `limit_inputs` rejects the input.
- Remove the now-unused `stress_categories_vals` array.

## Why this change is needed

`mapping()` was picking the numerically closest boundary value instead of classifying by range, which shifted every category transition to the midpoint of adjacent boundaries (26→32 transition moved to 29; inputs above 46 never returned "extreme heat stress"). Numerical `utci` was unaffected — only the `stress_category` string was wrong. Full repro in Issue #147.

## How I tested it

- [x] `npm test` — 1906 tests passed, 0 failed (37 new cases in `tests/models/utci.test.js` covering boundaries, midpoints, just-above transitions, and non-finite inputs)
- [x] `npm run build` — ESM + CJS succeeded
- [x] `npx prettier --write .` — no files rewritten

## Notes for reviewers

- `mapping()` is now exported from `utci.js` so tests can exercise it directly. Not added to `src/models/index.js`, so the top-level models registry is unchanged.
- `mapping_arr()` is untouched; it delegates to `mapping()` and inherits the fix for finite values. Cleanup is out of scope here.
- Public `utci()` signature is unchanged; only the returned `stress_category` string is corrected.

Closes #147
