### PR TITLE
fix(two_nodes): initialise nSimulation to 1

### DIFF
--- a/src/models/two_nodes.js
+++ b/src/models/two_nodes.js
@@ -491,7 +491,7 @@ function calculate_two_nodes(
 
   const pressureInAtmospheres = pAtmospheric / 101325;
   const lengthTimeSimulation = 60;
-  let nSimulation = 0;
+  let nSimulation = 1;
 
   const rClo = 0.155 * clo; // thermal resistance of clothing, C M^2 /W
   const fACl = 1.0 + 0.15 * clo; // increase in body surface area due to clothing


### PR DESCRIPTION
Starts `nSimulation` in `two_nodes` at `1` to match pythermalcomfort's `n_simulation`, so both implementations run the same 59 inner iterations.

Fixes #153.

## What

In `src/models/two_nodes.js`, change the `nSimulation` initial value from `0` to `1`. The `while`/increment structure is unchanged; after this one-line edit, the loop matches `pythermalcomfort/models/two_nodes_gagge.py` (`n_simulation = 1`, `while n_simulation < 60`, `n_simulation += 1`).

## Why

Row 7 of `ts_two_nodes_gagge.json` (inputs `tdb=45, tr=45, v=1.1, rh=20, met=3, clo=0.2`) fails on five fields against the shared validation dataset because JS runs one more convergence iteration than the Python reference. Issue #153 has the before/after table and the Row 6 note.

## How tested

- Row 7 values from calling `two_nodes` directly with the fix, against `ts_two_nodes_gagge.json` tolerances: `e_rsw` 244.25 vs 244.9 (tol 2), `e_skin` 253.12 vs 253.1 (tol 4), `m_rsw` 359.19 vs 359.2 (tol 6), `pmv_set` 2.24 vs 2.2 (tol 0.1), `disc` 5.34 vs 5.3 (tol 0.1) — all within tolerance
- Full Jest suite (`npm test`) passes, including the existing `two_nodes.test.js` harness meta-tests; row-level coverage of the validation dataset depends on the harness repair tracked in #154
- `npm run build` clean

Row 6's separate `disc` divergence remains tracked in #152.
