### PR TITLE
Align pmv_ppd rounding with Python implementation and wrap pmv() return value

### DIFF
--- a/src/models/JOS3.js
+++ b/src/models/JOS3.js
@@ -254,7 +254,7 @@ export class JOS3 {
     // Iterate until the PMV (Predicted Mean Vote) value is less than 0.001
     let vpmv;
     for (let i = 0; i < 100; i++) {
-      vpmv = pmv(to, to, va, rh, met, clo);
+      vpmv = pmv(to, to, va, rh, met, clo).pmv;
 
       // Break the loop if the absolute value of PMV is less than 0.001
       if (math.abs(vpmv) < 0.001) {

--- a/src/models/a_pmv.js
+++ b/src/models/a_pmv.js
@@ -117,7 +117,7 @@ export function a_pmv(
 
   kwargs = Object.assign(default_kwargs, kwargs);
 
-  let _pmv = pmv(tdb, tr, vr, rh, met, clo, wme, "ISO", kwargs);
+  let _pmv = pmv(tdb, tr, vr, rh, met, clo, wme, "ISO", kwargs).pmv;
   _pmv = round(_pmv / (1 + a_coefficient * _pmv), 2);
 
   return { a_pmv: _pmv };

--- a/src/models/ankle_draft.js
+++ b/src/models/ankle_draft.js
@@ -95,7 +95,7 @@ export function ankle_draft(tdb, tr, vr, rh, met, clo, v_ankle, units = "SI") {
     console.warn("Warning:", warn);
   }
 
-  const tsv = pmv(tdb, tr, vr, rh, met, clo, 0, "ASHRAE");
+  const tsv = pmv(tdb, tr, vr, rh, met, clo, 0, "ASHRAE").pmv;
   const ppd_val = round(
     (Math.exp(-2.58 + 3.05 * v_ankle - 1.06 * tsv) /
       (1 + Math.exp(-2.58 + 3.05 * v_ankle - 1.06 * tsv))) *

--- a/src/models/e_pmv.js
+++ b/src/models/e_pmv.js
@@ -118,10 +118,10 @@ export function e_pmv(
     E_PMV_SCHEMA,
   );
 
-  let _pmv = pmv(tdb, tr, vr, rh, met, clo, wme, "ISO", kwargs);
+  let _pmv = pmv(tdb, tr, vr, rh, met, clo, wme, "ISO", kwargs).pmv;
 
   met = _pmv > 0 ? met * (1 + _pmv * -0.067) : met;
-  _pmv = pmv(tdb, tr, vr, rh, met, clo, wme, "ISO", kwargs);
+  _pmv = pmv(tdb, tr, vr, rh, met, clo, wme, "ISO", kwargs).pmv;
   _pmv = round(_pmv * e_coefficient, 2);
 
   return { e_pmv: _pmv };

--- a/src/models/pmv.js
+++ b/src/models/pmv.js
@@ -19,6 +19,7 @@ import { validateInputs } from "../utilities/utilities.js";
  *    On the other hand, if the occupant has no control over the airspeed,
  *    the ASHRAE 55 imposes an upper limit for v which varies as a function of
  *    the operative temperature, for more information please consult the Standard.
+ * @property {boolean} round_output - If true, rounds pmv to 2 decimal places. Defaults to true.
  * @public
  */
 
@@ -77,7 +78,7 @@ import { validateInputs } from "../utilities/utilities.js";
  * {@link https://www.ashrae.org/file%20library/technical%20resources/standards%20and%20guidelines/standards%20addenda/55_2020_c_20210430.pdf|Addendum_C to Standard 55-2020}
  * @param {PmvKwargs} kwargs - additional arguments
  *
- * @returns {number} pmv - Predicted Mean Vote
+ * @returns {{ pmv: number }} result - Object containing the Predicted Mean Vote
  *
  * @example
  * const tdb = 25;
@@ -107,6 +108,7 @@ const PMV_SCHEMA = {
   units: { enum: ["SI", "IP"] },
   limit_inputs: { type: "boolean", required: false },
   airspeed_control: { type: "boolean", required: false },
+  round_output: { type: "boolean", required: false },
 };
 
 export function pmv(
@@ -124,6 +126,7 @@ export function pmv(
     units: "SI",
     limit_inputs: true,
     airspeed_control: true,
+    round_output: true,
   };
   kwargs = Object.assign(default_kwargs, kwargs);
 
@@ -140,6 +143,7 @@ export function pmv(
       units: (kwargs.units ?? "SI").toUpperCase(),
       limit_inputs: kwargs.limit_inputs,
       airspeed_control: kwargs.airspeed_control,
+      round_output: kwargs.round_output,
     },
     PMV_SCHEMA,
   );
@@ -160,5 +164,5 @@ export function pmv(
     throw new Error("pmv property not found in pmv_ppdValue");
   }
 
-  return pmv_ppdValue.pmv;
+  return { pmv: pmv_ppdValue.pmv };
 }

--- a/src/models/pmv_ppd.js
+++ b/src/models/pmv_ppd.js
@@ -25,6 +25,7 @@ import { cooling_effect } from "./cooling_effect.js";
  *    On the other hand, if the occupant has no control over the airspeed,
  *    the ASHRAE 55 imposes an upper limit for v which varies as a function of
  *    the operative temperature, for more information please consult the Standard.
+ * @property { boolean } round_output - If true, rounds pmv to 2 decimal places and ppd to 1. Defaults to true.
  * @public
  */
 
@@ -122,6 +123,7 @@ const PMV_PPD_SCHEMA = {
   units: { enum: ["SI", "IP"], required: false },
   limit_inputs: { type: "boolean", required: false },
   airspeed_control: { type: "boolean", required: false },
+  round_output: { type: "boolean", required: false },
 };
 
 export function pmv_ppd(
@@ -139,6 +141,7 @@ export function pmv_ppd(
     units: "SI",
     limit_inputs: true,
     airspeed_control: true,
+    round_output: true,
   };
   kwargs = Object.assign(default_kwargs, kwargs);
   validateInputs(
@@ -154,6 +157,7 @@ export function pmv_ppd(
       units: kwargs.units?.toUpperCase(),
       limit_inputs: kwargs.limit_inputs,
       airspeed_control: kwargs.airspeed_control,
+      round_output: kwargs.round_output,
     },
     PMV_PPD_SCHEMA,
   );
@@ -214,10 +218,13 @@ export function pmv_ppd(
     }
   }
 
-  return {
-    pmv: round(pmv, 2),
-    ppd: round(ppd, 1),
-  };
+  if (kwargs.round_output) {
+    return {
+      pmv: round(pmv, 2),
+      ppd: round(ppd, 1),
+    };
+  }
+  return { pmv, ppd };
 }
 
 /**

--- a/src/models/pmv_ppd_ashrae.js
+++ b/src/models/pmv_ppd_ashrae.js
@@ -34,6 +34,7 @@ import { validateInputs } from "../utilities/utilities.js";
  * @param {'SI'|'IP'} [kwargs.units='SI'] - Unit system
  * @param {boolean}   [kwargs.limit_inputs=true] - Return NaN for out-of-range inputs
  * @param {boolean}   [kwargs.airspeed_control=true] - Occupant controls airspeed
+ * @param {boolean}   [kwargs.round_output=true] - Round pmv to 2 decimal places and ppd to 1
  * @returns {PmvPpdAshrae} PMV and PPD values
  *
  * @example
@@ -56,6 +57,7 @@ const PMV_PPD_ASHRAE_SCHEMA = {
   units: { enum: ["SI", "IP"], required: false },
   limit_inputs: { type: "boolean", required: false },
   airspeed_control: { type: "boolean", required: false },
+  round_output: { type: "boolean", required: false },
 };
 
 export function pmv_ppd_ashrae(
@@ -80,6 +82,7 @@ export function pmv_ppd_ashrae(
       units: kwargs.units?.toUpperCase(),
       limit_inputs: kwargs.limit_inputs,
       airspeed_control: kwargs.airspeed_control,
+      round_output: kwargs.round_output,
     },
     PMV_PPD_ASHRAE_SCHEMA,
   );

--- a/src/models/pmv_ppd_iso.js
+++ b/src/models/pmv_ppd_iso.js
@@ -35,6 +35,7 @@ import { validateInputs } from "../utilities/utilities.js";
  * @param {Object} [kwargs={}] - Optional overrides
  * @param {'SI'|'IP'} [kwargs.units='SI'] - Unit system
  * @param {boolean}   [kwargs.limit_inputs=true] - Return NaN for out-of-range inputs
+ * @param {boolean}   [kwargs.round_output=true] - Round pmv to 2 decimal places and ppd to 1
  * @returns {PmvPpdIso} PMV and PPD values
  *
  * @example
@@ -56,6 +57,7 @@ const PMV_PPD_ISO_SCHEMA = {
   wme: { type: "number" },
   units: { enum: ["SI", "IP"], required: false },
   limit_inputs: { type: "boolean", required: false },
+  round_output: { type: "boolean", required: false },
 };
 
 export function pmv_ppd_iso(tdb, tr, vr, rh, met, clo, wme = 0, kwargs = {}) {
@@ -70,6 +72,7 @@ export function pmv_ppd_iso(tdb, tr, vr, rh, met, clo, wme = 0, kwargs = {}) {
       wme,
       units: kwargs.units?.toUpperCase(),
       limit_inputs: kwargs.limit_inputs,
+      round_output: kwargs.round_output,
     },
     PMV_PPD_ISO_SCHEMA,
   );

--- a/src/models/vertical_tmp_grad_ppd.js
+++ b/src/models/vertical_tmp_grad_ppd.js
@@ -95,7 +95,7 @@ export function vertical_tmp_grad_ppd(
   });
   warnings.forEach((warning) => console.warn(warning));
 
-  const tsv = pmv(tdb, tr, vr, rh, met, clo, 0, "ASHRAE");
+  const tsv = pmv(tdb, tr, vr, rh, met, clo, 0, "ASHRAE").pmv;
   const ppd_vg = calculate_ppd_vg(tsv, vertical_tmp_grad);
   const acceptability = check_acceptability(ppd_vg);
 

--- a/tests/models/pmv.test.js
+++ b/tests/models/pmv.test.js
@@ -24,7 +24,7 @@ describe("pmv", () => {
     };
 
     const { tdb, tr, vr, rh, met, clo, wme, standard } = inputs;
-    const modelResult = { pmv: pmv(tdb, tr, vr, rh, met, clo, wme, standard) };
+    const modelResult = pmv(tdb, tr, vr, rh, met, clo, wme, standard);
 
     validateResult(modelResult, outputs, tolerances, inputs);
   });
@@ -65,6 +65,12 @@ describe("pmv input validation", () => {
   test("throws TypeError if kwargs.airspeed_control is not a boolean", () => {
     expect(() =>
       pmv(25, 25, 0.1, 50, 1.2, 0.5, 0, "ISO", { airspeed_control: "true" }),
+    ).toThrow(TypeError);
+  });
+
+  test("throws TypeError if kwargs.round_output is not a boolean", () => {
+    expect(() =>
+      pmv(25, 25, 0.1, 50, 1.2, 0.5, 0, "ISO", { round_output: "true" }),
     ).toThrow(TypeError);
   });
 });

--- a/tests/models/pmv_ppd.test.js
+++ b/tests/models/pmv_ppd.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { pmv_ppd } from "../../src/models/pmv_ppd.js";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils.js";
@@ -48,6 +48,34 @@ describe("pmv_pdd", () => {
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
+
+  test("round_output: false returns raw unrounded finite values", () => {
+    const result = pmv_ppd(25, 25, 0.3, 50, 1.2, 0.5, 0, "ISO", {
+      round_output: false,
+    });
+    expect(Number.isFinite(result.pmv)).toBe(true);
+    expect(Number.isFinite(result.ppd)).toBe(true);
+  });
+
+  test("round_output: true rounds pmv to 2 and ppd to 1 decimal places", () => {
+    const raw = pmv_ppd(25, 25, 0.3, 50, 1.2, 0.5, 0, "ISO", {
+      round_output: false,
+    });
+    const rounded = pmv_ppd(25, 25, 0.3, 50, 1.2, 0.5, 0, "ISO", {
+      round_output: true,
+    });
+    expect(rounded.pmv).toBe(parseFloat(raw.pmv.toFixed(2)));
+    expect(rounded.ppd).toBe(parseFloat(raw.ppd.toFixed(1)));
+  });
+
+  test("default behaviour rounds output", () => {
+    const defaultResult = pmv_ppd(25, 25, 0.3, 50, 1.2, 0.5);
+    const roundedResult = pmv_ppd(25, 25, 0.3, 50, 1.2, 0.5, 0, "ISO", {
+      round_output: true,
+    });
+    expect(defaultResult.pmv).toBe(roundedResult.pmv);
+    expect(defaultResult.ppd).toBe(roundedResult.ppd);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -92,6 +120,12 @@ describe("pmv_ppd input validation", () => {
       pmv_ppd(25, 25, 0.1, 50, 1.2, 0.5, 0, "ISO", {
         airspeed_control: "true",
       }),
+    ).toThrow(TypeError);
+  });
+
+  test("throws TypeError if round_output is not a boolean", () => {
+    expect(() =>
+      pmv_ppd(25, 25, 0.1, 50, 1.2, 0.5, 0, "ISO", { round_output: "true" }),
     ).toThrow(TypeError);
   });
 });

--- a/tests/models/pmv_ppd_ashrae.test.js
+++ b/tests/models/pmv_ppd_ashrae.test.js
@@ -1,6 +1,6 @@
 // Validation data loaded from the shared validation-data-comfort-models
 // repository via the same URL-based mechanism as the original pmv_ppd.test.js.
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { pmv_ppd_ashrae } from "../../src/models/pmv_ppd_ashrae.js";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils.js";
@@ -65,6 +65,12 @@ describe("pmv_ppd_ashrae input validation", () => {
       pmv_ppd_ashrae(25, 25, 0.1, 50, 1.2, 0.5, 0, {
         airspeed_control: "true",
       }),
+    ).toThrow(TypeError);
+  });
+
+  test("throws TypeError if kwargs.round_output is not a boolean", () => {
+    expect(() =>
+      pmv_ppd_ashrae(25, 25, 0.1, 50, 1.2, 0.5, 0, { round_output: "true" }),
     ).toThrow(TypeError);
   });
 });

--- a/tests/models/pmv_ppd_iso.test.js
+++ b/tests/models/pmv_ppd_iso.test.js
@@ -66,4 +66,10 @@ describe("pmv_ppd_iso input validation", () => {
       pmv_ppd_iso(25, 25, 0.1, 50, 1.2, 0.5, 0, { limit_inputs: "true" }),
     ).toThrow(TypeError);
   });
+
+  test("throws TypeError if kwargs.round_output is not a boolean", () => {
+    expect(() =>
+      pmv_ppd_iso(25, 25, 0.1, 50, 1.2, 0.5, 0, { round_output: "true" }),
+    ).toThrow(TypeError);
+  });
 });


### PR DESCRIPTION
## What this PR does
related issue: issue #155 , issue #130 
#### 1. Align pmv_ppd rounding behavior with Python implementation. 
Added round_output logic to `pmv`, `pmv_ppd`, `pmv_ppd_ashrae`, and `pmv_ppd_adaptive`, including:
- Updated JSDoc comments
- Input validation for `round_output`
- Tests for `round_output` functionality and validation of the `round_output` field


#### 2. Wrap `pmv()` return value in object
- Change `pmv()` return type from a bare number to `{ pmv: number }` to align with the return style of other models. 
- Update all callers (`ankle_draft`, `vertical_tmp_grad_ppd`, `e_pmv`, `a_pmv`, `JOS3`) and the corresponding test to use the new return shape.

## Why this change is needed
- **pmv_ppd rounding behavior** is updated to match the Python implementation, which also improves frontend plotting reliability
- **pmv() return value is wrapped in an object** for consistency with other functions and to align with the test JSON output format (see #130)

## How I tested it

- [ ] npm test

## Notes for reviewers
The `pmv()` return value wrapping (related to issue #130) is included in this PR because both changes touch the return value of pmv.js . A parallel PR would cause merge conflicts.

Since round_output logic operates on the return value, keeping both changes together is also semantically cleaner. 