### PR TITLE
fix: remove lodash/object.js import

### DIFF
--- a/src/models/JOS3.js
+++ b/src/models/JOS3.js
@@ -40,7 +40,6 @@ import { local_q_work } from "../jos3_functions/thermoregulation/local_q_work.js
 import { cr_ms_fat_blood_flow } from "../jos3_functions/thermoregulation/cr_ms_fat_blood_flow.js";
 import { resp_heat_loss } from "../jos3_functions/thermoregulation/resp_heat_loss.js";
 import { sum_bf } from "../jos3_functions/thermoregulation/sum_bf.js";
-import Object from "lodash/object.js";
 
 /**
  * Create an array of shape (17,) with the given input.


### PR DESCRIPTION
This is a small one-line change in JOS3.js that removes an import for lodash/object.js, which is not being used within the file and can cause build issues for comfort-tool.