### PR TITLE
feat(utilities): add maskOutOfRange helper for post-validation range masking

### DIFF
--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -9,6 +9,7 @@ import {
   clo_typical_ensembles,
   clo_individual_garments,
   check_standard_compliance_array,
+  maskOutOfRange,
 } from "./utilities.js";
 
 /**
@@ -27,6 +28,7 @@ export {
   clo_typical_ensembles,
   clo_individual_garments,
   check_standard_compliance_array,
+  maskOutOfRange,
 };
 
 export default {

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -928,3 +928,73 @@ export const validateInputs = (params, schema) => {
     }
   }
 };
+
+/**
+ * Replaces values that fall outside their declared `[min, max]` range with
+ * `NaN`, mirroring the range-check stage of pythermalcomfort's `valid_range`.
+ *
+ * Intended as the post-validation range mask in the model entry path. Callers
+ * should pass each input through `validateInputs` first (the PR #145 type
+ * gate, which throws `TypeError` for non-numeric or non-finite values) and
+ * then call this helper to collapse out-of-range numeric values to `NaN`.
+ *
+ * Scalars are replaced wholesale; arrays are checked per element. Scope is
+ * per-parameter only — cross-parameter rules, for example ASHRAE's
+ * `airspeed_control` cross-field check, are not handled here and remain the
+ * caller's responsibility (see `check_standard_compliance`).
+ *
+ * Direct utility callers (tests, debug, ad-hoc tooling) that bypass
+ * `validateInputs` get a secondary defensive layer: each value passes through
+ * `Number.isFinite` before the range comparison, so non-numbers (`"25"`,
+ * `true`, `null`) and `Infinity`/`NaN` collapse to `NaN` without coercion.
+ * On the model entry path this branch is unreachable because `validateInputs`
+ * has already thrown; the guard exists for direct utility use only.
+ *
+ * Schema scope: only list a key in `schema` if you want it range-masked. An
+ * omitted optional caller param that arrives as `undefined` will collapse to
+ * `NaN` if the same key is also in `schema`, which is rarely the desired
+ * outcome — keep optional params out of the schema unless that collapse is
+ * intentional.
+ *
+ * Keys present in `params` but absent from `schema` pass through unchanged.
+ * Keys named in `schema` but missing from `params` are skipped silently (the
+ * key is not added to the result). The input `params` object is never mutated;
+ * a shallow copy is returned so callers can replace their working set in place.
+ *
+ * @param {Object.<string, number | number[]>} params - input values keyed by name
+ * @param {Object.<string, { min: number, max: number }>} schema - per-parameter
+ *   inclusive `[min, max]` range to enforce
+ * @returns {Object.<string, number | number[]>} a new object with the same keys
+ *   as `params`, where any value or array element outside its schema range, or
+ *   not a finite number, has been replaced by `NaN`
+ *
+ * @example
+ * maskOutOfRange(
+ *   { tdb: 45, met: 1.2, clo: [0.3, 2.5, NaN] },
+ *   {
+ *     tdb: { min: 10, max: 40 },
+ *     met: { min: 1.0, max: 4.0 },
+ *     clo: { min: 0.0, max: 1.5 },
+ *   },
+ * );
+ * // → { tdb: NaN, met: 1.2, clo: [0.3, NaN, NaN] }
+ */
+export const maskOutOfRange = (params, schema) => {
+  // Shallow copy so callers, and the input itself, are never mutated.
+  const result = { ...params };
+  for (const [key, { min, max }] of Object.entries(schema)) {
+    if (!(key in result)) continue;
+    const value = result[key];
+    if (Array.isArray(value)) {
+      // Number.isFinite avoids coercion for direct utility callers; on the
+      // model entry path validateInputs has already thrown for non-numbers.
+      result[key] = value.map((n) =>
+        Number.isFinite(n) && n >= min && n <= max ? n : NaN,
+      );
+    } else {
+      result[key] =
+        Number.isFinite(value) && value >= min && value <= max ? value : NaN;
+    }
+  }
+  return result;
+};

--- a/tests/utilities/utilities.test.js
+++ b/tests/utilities/utilities.test.js
@@ -12,6 +12,7 @@ import {
   transpose_sharp_altitude,
   assertNumber,
   validateInputs,
+  maskOutOfRange,
 } from "../../src/utilities/utilities";
 import {
   deep_close_to_array,
@@ -596,5 +597,123 @@ describe("validateInputs", () => {
         ),
       ).not.toThrow();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maskOutOfRange
+// ---------------------------------------------------------------------------
+describe("maskOutOfRange", () => {
+  it("leaves a scalar value within range untouched", () => {
+    const result = maskOutOfRange({ tdb: 25 }, { tdb: { min: 10, max: 40 } });
+    expect(result.tdb).toBe(25);
+  });
+
+  it("replaces an out-of-range scalar with NaN", () => {
+    const result = maskOutOfRange({ tdb: 45 }, { tdb: { min: 10, max: 40 } });
+    expect(result.tdb).toBeNaN();
+  });
+
+  it("replaces only out-of-range elements in an array", () => {
+    const result = maskOutOfRange(
+      { clo: [0.3, 2.5, 1.0, -0.1] },
+      { clo: { min: 0.0, max: 1.5 } },
+    );
+    expect(result.clo[0]).toBe(0.3);
+    expect(result.clo[1]).toBeNaN();
+    expect(result.clo[2]).toBe(1.0);
+    expect(result.clo[3]).toBeNaN();
+  });
+
+  it("passes a NaN scalar through as NaN", () => {
+    const result = maskOutOfRange({ tdb: NaN }, { tdb: { min: 10, max: 40 } });
+    expect(result.tdb).toBeNaN();
+  });
+
+  it("passes a NaN array element through as NaN at the same index", () => {
+    const result = maskOutOfRange(
+      { tdb: [25, NaN, 30] },
+      { tdb: { min: 10, max: 40 } },
+    );
+    expect(result.tdb[0]).toBe(25);
+    expect(result.tdb[1]).toBeNaN();
+    expect(result.tdb[2]).toBe(30);
+  });
+
+  it("leaves a params key untouched when it has no schema rule", () => {
+    const result = maskOutOfRange(
+      { tdb: 25, units: "SI" },
+      { tdb: { min: 10, max: 40 } },
+    );
+    expect(result.units).toBe("SI");
+  });
+
+  it("does not error and produces no key when the schema names a missing param", () => {
+    const result = maskOutOfRange(
+      { tdb: 25 },
+      { tdb: { min: 10, max: 40 }, met: { min: 1.0, max: 4.0 } },
+    );
+    expect(result.tdb).toBe(25);
+    expect("met" in result).toBe(false);
+  });
+
+  it("returns a fresh object without mutating the input", () => {
+    const params = { tdb: 45, clo: [0.3, 2.5] };
+    const result = maskOutOfRange(params, {
+      tdb: { min: 10, max: 40 },
+      clo: { min: 0.0, max: 1.5 },
+    });
+    expect(result).not.toBe(params);
+    expect(params.tdb).toBe(45);
+    expect(params.clo).toEqual([0.3, 2.5]);
+  });
+
+  it("retains a scalar value at the inclusive lower boundary", () => {
+    const result = maskOutOfRange({ tdb: 10 }, { tdb: { min: 10, max: 40 } });
+    expect(result.tdb).toBe(10);
+  });
+
+  it("retains a scalar value at the inclusive upper boundary", () => {
+    const result = maskOutOfRange({ tdb: 40 }, { tdb: { min: 10, max: 40 } });
+    expect(result.tdb).toBe(40);
+  });
+
+  it("treats array boundaries inclusively and rejects values just outside", () => {
+    const result = maskOutOfRange(
+      { tdb: [10, 40, 9.99, 40.01] },
+      { tdb: { min: 10, max: 40 } },
+    );
+    expect(result.tdb[0]).toBe(10);
+    expect(result.tdb[1]).toBe(40);
+    expect(result.tdb[2]).toBeNaN();
+    expect(result.tdb[3]).toBeNaN();
+  });
+
+  it("masks non-number scalar inputs to NaN for direct utility use", () => {
+    const schema = { tdb: { min: 10, max: 40 } };
+    expect(maskOutOfRange({ tdb: "25" }, schema).tdb).toBeNaN();
+    expect(maskOutOfRange({ tdb: true }, schema).tdb).toBeNaN();
+    expect(maskOutOfRange({ tdb: null }, schema).tdb).toBeNaN();
+    expect(maskOutOfRange({ tdb: undefined }, schema).tdb).toBeNaN();
+    expect(maskOutOfRange({ tdb: Infinity }, schema).tdb).toBeNaN();
+  });
+
+  it("masks non-finite array elements to NaN for direct utility use", () => {
+    const result = maskOutOfRange(
+      { clo: [true, "0.5", null, 2] },
+      { clo: { min: 0, max: 1.5 } },
+    );
+    expect(result.clo[0]).toBeNaN();
+    expect(result.clo[1]).toBeNaN();
+    expect(result.clo[2]).toBeNaN();
+    expect(result.clo[3]).toBeNaN();
+  });
+
+  it("retains an in-range finite-number scalar", () => {
+    const result = maskOutOfRange(
+      { met: 1.2 },
+      { met: { min: 1.0, max: 4.0 } },
+    );
+    expect(result.met).toBe(1.2);
   });
 });


### PR DESCRIPTION
Adds a shared `maskOutOfRange(params, schema)` helper to `src/utilities/utilities.js` to support the range-check stage tracked in #142.

The helper walks a `{ paramName: { min, max } }` schema and returns a shallow-copied params object with each finite numeric value outside its `[min, max]` range replaced by `NaN` (per-element for arrays). The numeric range masking mirrors pythermalcomfort's `valid_range`. Inputs are not mutated.

**Positioning.** Intended as the post-validation range mask in the model entry path. Callers should pass each input through `validateInputs` first (the PR #145 type gate, which throws `TypeError` on non-numeric or non-finite inputs) and then call `maskOutOfRange` to collapse out-of-range numeric values to `NaN`. This matches the `TypeError` for invalid types / `NaN` for out-of-range split documented in `CLAUDE.md` §11.

**Direct utility callers.** Tests, debug scripts, and ad-hoc tooling that bypass `validateInputs` get a secondary defensive layer: each value passes through `Number.isFinite` before the range comparison, so non-numbers (`"25"`, `true`, `null`) and `Infinity`/`NaN` collapse to `NaN` without coercion. On the model entry path this branch is unreachable because `validateInputs` has already thrown; the guard exists for direct utility use only.

**Schema scope.** Only list a key in `schema` if you want it range-masked. An omitted optional caller param that arrives as `undefined` will collapse to `NaN` if the same key is also in `schema`, which is rarely the desired outcome — keep optional params out of the schema unless that collapse is intentional.

Params keys without schema rules are left unchanged; schema keys missing from params are skipped without adding new keys.

Models tracked in #142 need a uniform range guard before computation, and centralising the logic avoids per-model drift.

Scope is helper-only. No model is wired in this PR; model wiring will land in follow-up PRs to keep each change reviewable.

Tested locally with `npm test` on Node 22.x — 68 suites / 2145 tests pass. Unit tests cover scalar in/out-of-range, array per-element, `NaN` passthrough at scalar and array level, schema/params key gaps, input non-mutation, inclusive `[min, max]` boundaries, and the `Number.isFinite` guard for direct utility callers (strings, booleans, `null`, `undefined`, `Infinity`).

Refs #142.
