### PR TITLE
Fix wbgt() return format and round_output option (#130)

### DIFF
--- a/src/models/wbgt.js
+++ b/src/models/wbgt.js
@@ -1,7 +1,7 @@
 import { round, validateInputs } from "../utilities/utilities.js";
 
 const optionDefaults = {
-  round: true,
+  round_output: true,
   tdb: undefined,
   with_solar_load: false,
 };
@@ -38,7 +38,7 @@ const optionDefaults = {
  * @param {number} twb - natural (no forced air flow) wet bulb temperature, [°C]
  * @param {number} tg - globe temperature, [°C]
  * @param {object} [options] - configuration options for the function.
- * @param {boolean} [options.round = true] - If true rounds output value. If
+ * @param {boolean} [options.round_output = true] - If true rounds output value. If
  * false it does not round it.
  * @param {number} [options.tdb = undefined] - Dry bulb air temperature, [°C].
  * This value is needed as input if the person is exposed to direct solar
@@ -60,7 +60,7 @@ const optionDefaults = {
 const WBGT_SCHEMA = {
   twb: { type: "number" },
   tg: { type: "number" },
-  round: { type: "boolean", required: false },
+  round_output: { type: "boolean", required: false },
   tdb: { type: "number", required: false },
   with_solar_load: { type: "boolean", required: false },
 };
@@ -71,7 +71,7 @@ export function wbgt(twb, tg, options) {
     {
       twb,
       tg,
-      round: opt.round,
+      round_output: opt.round_output,
       tdb: opt.tdb,
       with_solar_load: opt.with_solar_load,
     },
@@ -90,8 +90,8 @@ export function wbgt(twb, tg, options) {
     t_wbg = 0.7 * twb + 0.3 * tg;
   }
 
-  if (opt.round) {
-    return round(t_wbg, 1);
+  if (opt.round_output) {
+    t_wbg = round(t_wbg, 1);
   }
 
   return { wbgt: t_wbg };

--- a/tests/models/wbgt.test.js
+++ b/tests/models/wbgt.test.js
@@ -14,8 +14,8 @@ let { testData, tolerances } = await loadTestData(
 describe("wbgt", () => {
   test.each(testData.data)("Test case #%#", (testCase) => {
     const { inputs, outputs: expectedOutput } = testCase;
-    const { twb, tg, tdb, with_solar_load, round } = inputs;
-    const modelResult = wbgt(twb, tg, { tdb, with_solar_load, round });
+    const { twb, tg, tdb, with_solar_load, round_output } = inputs;
+    const modelResult = wbgt(twb, tg, { tdb, with_solar_load, round_output });
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
@@ -27,6 +27,22 @@ describe("wbgt", () => {
       // Verify specific error message
       expect(error.message).toBe("Please enter the dry bulb air temperature");
     }
+  });
+
+  it("round_output:true returns value rounded to 1 decimal place", () => {
+    const result = wbgt(17.3, 40, { round_output: true });
+    expect(result.wbgt).toBe(24.1);
+  });
+
+  it("round_output:false returns unrounded value", () => {
+    const result = wbgt(17.3, 40, { round_output: false });
+    expect(result.wbgt).toBeCloseTo(24.11, 5);
+  });
+
+  it("round_output:true and round_output:false produce different results", () => {
+    const rounded = wbgt(17.3, 40, { round_output: true }).wbgt;
+    const unrounded = wbgt(17.3, 40, { round_output: false }).wbgt;
+    expect(rounded).not.toBe(unrounded);
   });
 });
 
@@ -45,8 +61,8 @@ describe("wbgt input validation", () => {
     expect(() => wbgt(25, 32, { tdb: "20" })).toThrow(TypeError);
   });
 
-  test("throws TypeError if round is not a boolean", () => {
-    expect(() => wbgt(25, 32, { round: "true" })).toThrow(TypeError);
+  test("throws TypeError if round_output is not a boolean", () => {
+    expect(() => wbgt(25, 32, { round_output: "true" })).toThrow(TypeError);
   });
 
   test("throws TypeError if with_solar_load is not a boolean", () => {


### PR DESCRIPTION
## What this PR does

### 1. Addresses issue #130

- All models under `src/models` except `JOS3` were checked.
- Models `pmv` and `wbgt` were found to return a bare number rather than an object.
- `pmv`'s return type was fixed by PR #160.

This PR focuses on model `wbgt`, fixing it always returning a bare number when `round_output` is `true` instead of the documented `{ wbgt }` object format.


### 2. Fix parameter naming and test coverage in `wbgt` model

**Bug found**
- The parameter used to control round output behavior is named `round` in the model, but `round_output` in the validation data. As a result, `round` is always `undefined` when `round_output` is passed in, causing validation cases that involve `round_output` to silently pass through without actually testing rounding behavior.
- A secondary issue: the tolerance defined in the validation data is `0.1`, while `round_output` rounds values to one decimal place. This means a value like `24.11` — even if not correctly rounded — would still pass the test. Since `24.11 - 24.1 = 0.01` and `0.01 < 0.1 (tolerance)`. The two issues combined meant rounding was never truly validated.

**Fix**
- Rename option `round` to `round_output` to match the Python implementation and the `pmv` family convention.
- Add inline tests that explicitly verify `round_output` behavior using exact equality checks, bypassing the loose tolerance in the remote test data.

## Why this change is needed

- To improve consistency across the library, as tracked in issue #130. All thermal comfort models should return a named object rather than a bare number, and option parameter names should align with the Python implementation and the pmv family convention.
- The `wbgt` model's `round_output` behavior has never been properly validated in tests, leaving the rounding path untested despite appearing to have coverage.

## How I tested it
- [ ] npm test

## Notes for reviewers

- The rename from `round` to `round_output` is a **breaking change** for any caller currently passing the option as `{round: true}` — worth noting in the changelog or release notes.
