### PR TITLE
chore(deps): override postcss to address dev-only audit finding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5640,9 +5640,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {
@@ -5658,11 +5658,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -6283,10 +6284,11 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
   "dependencies": {
     "mathjs": "^15.2.0",
     "node-fetch": "^3.3.2"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## What this PR does

- Add `overrides` block in package.json pinning `postcss` to `^8.5.10`.

## Why this change is needed

- `npm audit` reports 3 moderate vulnerabilities; one is GHSA-qx2v-qp2m-jg93 (XSS via unescaped `</style>` in postcss CSS output, range `<8.5.10`).
- postcss enters the tree only via the `documentation` build tool. It is not shipped in `lib/`, so the advisory is contained to local docs builds, but it adds noise to every `npm audit` run.
- The override resolves postcss to 8.5.13 (current tree was on 8.4.31), which is outside the GHSA fix range. It does this without forcing a breaking downgrade of `documentation` itself, which `npm audit fix --force` would do (dropping `documentation` from 14.x to 6.x).

## How I tested it

- [x] `npm test` (2150 tests pass, no regressions)
- [x] `npm run build`
- [x] `npm audit` reduces from 3 to 2 moderate; postcss finding cleared
- [x] Verified `overrides` is contained to root: nested `package.json` overrides are ignored by npm, so downstream consumers of jsthermalcomfort are not affected.

## Notes for reviewers

- The remaining 2 audit findings are vue-template-compiler 2.x via documentation. That dep is an `optionalDependency` of `documentation` and unreachable in this project (no Vue SFCs / templates). `documentation@14.0.3` is the latest published version; no clean upstream fix available yet, so this is left to a follow-up after `documentation` upstream lands a non-Vue 2 path.