### PR TITLE
Add relative humidity range check to humidex

### DIFF
--- a/src/models/humidex.js
+++ b/src/models/humidex.js
@@ -18,8 +18,8 @@ import { round, validateInputs } from "../utilities/utilities.js";
  * Humidex differs from the heat index in being related to the dew point
  * rather than relative humidity {@link #ref_15|[15]}.
  *
- * Relative humidity outside [0, 100] returns
- * `{ humidex: NaN, discomfort: NaN }`.
+ * Relative humidity outside [0, 100] is physically invalid and throws a
+ * `RangeError`.
  *
  * @public
  * @memberof models
@@ -30,6 +30,8 @@ import { round, validateInputs } from "../utilities/utilities.js";
  * @param {object} [options] - configuration options for the function.
  * @param {boolean} [options.round = true] - If true, rounds output value. If
  * false, it does not.
+ *
+ * @throws {RangeError} when `rh` is outside `[0, 100]`.
  *
  * @returns {HumidexResult} the result given the provided temperature and
  * relative humidity.
@@ -48,7 +50,7 @@ export function humidex(tdb, rh, options = { round: true }) {
   validateInputs({ tdb, rh, round: options.round }, HUMIDEX_SCHEMA);
 
   if (rh < 0 || rh > 100) {
-    return { humidex: NaN, discomfort: NaN };
+    throw new RangeError("Relative humidity must be between 0 and 100%");
   }
 
   let hi =

--- a/src/models/humidex.js
+++ b/src/models/humidex.js
@@ -18,6 +18,9 @@ import { round, validateInputs } from "../utilities/utilities.js";
  * Humidex differs from the heat index in being related to the dew point
  * rather than relative humidity {@link #ref_15|[15]}.
  *
+ * Relative humidity outside [0, 100] returns
+ * `{ humidex: NaN, discomfort: NaN }`.
+ *
  * @public
  * @memberof models
  * @docname Humidex
@@ -43,6 +46,10 @@ const HUMIDEX_SCHEMA = {
 
 export function humidex(tdb, rh, options = { round: true }) {
   validateInputs({ tdb, rh, round: options.round }, HUMIDEX_SCHEMA);
+
+  if (rh < 0 || rh > 100) {
+    return { humidex: NaN, discomfort: NaN };
+  }
 
   let hi =
     tdb +

--- a/tests/models/humidex.test.js
+++ b/tests/models/humidex.test.js
@@ -1,7 +1,9 @@
-import { describe } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { humidex } from "../../src/models/humidex";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
+
+// Validated against pythermalcomfort 3.9.3.
 
 let returnArray = false;
 
@@ -34,5 +36,31 @@ describe("humidex input validation", () => {
 
   test("throws TypeError if round is not a boolean", () => {
     expect(() => humidex(25, 50, { round: "true" })).toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Out-of-range relative humidity returns NaN. pythermalcomfort 3.9.3 raises
+// ValueError for the same inputs.
+// ---------------------------------------------------------------------------
+describe("humidex out-of-range relative humidity", () => {
+  test.each([
+    ["rh below 0", 25, -0.1],
+    ["rh well below 0", 25, -25],
+    ["rh just above 100", 25, 100.1],
+    ["rh well above 100", 25, 150],
+  ])("returns NaN when %s", (_, tdb, rh) => {
+    const result = humidex(tdb, rh);
+    expect(result.humidex).toBeNaN();
+    expect(result.discomfort).toBeNaN();
+  });
+
+  test.each([
+    ["rh at lower bound", 25, 0],
+    ["rh at upper bound", 25, 100],
+  ])("returns a finite humidex when %s", (_, tdb, rh) => {
+    const result = humidex(tdb, rh);
+    expect(Number.isFinite(result.humidex)).toBe(true);
+    expect(typeof result.discomfort).toBe("string");
   });
 });

--- a/tests/models/humidex.test.js
+++ b/tests/models/humidex.test.js
@@ -40,8 +40,8 @@ describe("humidex input validation", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Out-of-range relative humidity returns NaN. pythermalcomfort 3.9.3 raises
-// ValueError for the same inputs.
+// Relative humidity outside [0, 100] is physically invalid and throws
+// RangeError, matching pythermalcomfort 3.9.3 (which raises ValueError).
 // ---------------------------------------------------------------------------
 describe("humidex out-of-range relative humidity", () => {
   test.each([
@@ -49,10 +49,8 @@ describe("humidex out-of-range relative humidity", () => {
     ["rh well below 0", 25, -25],
     ["rh just above 100", 25, 100.1],
     ["rh well above 100", 25, 150],
-  ])("returns NaN when %s", (_, tdb, rh) => {
-    const result = humidex(tdb, rh);
-    expect(result.humidex).toBeNaN();
-    expect(result.discomfort).toBeNaN();
+  ])("throws RangeError when %s", (_, tdb, rh) => {
+    expect(() => humidex(tdb, rh)).toThrow(RangeError);
   });
 
   test.each([


### PR DESCRIPTION
## What this PR does

- Adds a `[0, 100]` range check on `rh` in `humidex()`.
- Out-of-range relative humidity now throws `RangeError` because it is physically invalid input, matching pythermalcomfort 3.9.3's `ValueError` behaviour.
- Adds 4 out-of-range throw cases (rh = -25, -0.1, 100.1, 150) and 2 boundary sanity cases (rh = 0, rh = 100).

## Why this change is needed

- Part of #142 (input validation across all models).
- pythermalcomfort 3.9.3 raises `ValueError` for `rh` outside `[0, 100]`. `RangeError` is the JavaScript analogue for value-domain violations on a valid type.
- Keeps `humidex` in the physically invalid input category rather than the applicability-limit category that returns `NaN` under `limit_inputs`.

## How I tested it

- [x] `npm test` (2150 -> 2156 tests in the original push; final branch adds 4 throw cases + 2 boundary cases)
- [x] `npm run build`
- [x] `node --experimental-vm-modules ./node_modules/.bin/jest --testPathPattern="humidex"` in a temporary worktree for the final head commit: 28 tests passed

## Notes for reviewers

- No fixture changes needed: every existing `humidex` validation case has rh in `[0, 100]`.
- The range check is inline and does not touch `validateInputs()`, so it should not conflict with #169's shared min/max schema work.
- Test file picks up `expect, test` in the import line; the new describe block was relying on implicit globals, so this is a tiny side cleanup, not a behaviour change.
