### PR TITLE
Gate heat_index tdb < 27 °C to NaN by default

### DIFF
--- a/docs_theme/changelog.md
+++ b/docs_theme/changelog.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## 2.0.0 (TBD)
+
+- `heat_index` now returns `{ hi: NaN }` by default when `tdb < 27 °C`, matching `pythermalcomfort` 3.9.3 `heat_index_rothfusz`. IP mode uses the equivalent threshold, `tdb < 80.6 °F`, so the same physical temperature is accepted or rejected regardless of unit system. This is a breaking change compared with previous versions; callers needing the previous behaviour should pass `{ limit_inputs: false }`.
+
 ## 1.2.0
 
 - Removed `check_standard_compliance_array` from public exports. This is a breaking change for consumers that imported the array helper directly. Internal callers (`adaptive_ashrae`, `pmv_ppd`, `set_tmp`, `use_fans_heatwaves`) have been migrated to the scalar `check_standard_compliance` helper, which now also covers the ASHRAE `airspeed_control` cross-field check (pass `airspeed_control: false` to enable) and the `FAN_HEATWAVES` standard.

--- a/docs_theme/changelog.md
+++ b/docs_theme/changelog.md
@@ -1,6 +1,6 @@
 All notable changes to this project will be documented in this file.
 
-## 2.0.0
+## 1.3.0
 
 - `heat_index` now returns `{ hi: NaN }` by default when `tdb < 27 °C`, matching `pythermalcomfort` 3.9.3 `heat_index_rothfusz`. IP mode uses the equivalent threshold, `tdb < 80.6 °F`, so the same physical temperature is accepted or rejected regardless of unit system. This is a breaking change compared with previous versions; callers needing the previous behaviour should pass `{ limit_inputs: false }`.
 

--- a/docs_theme/changelog.md
+++ b/docs_theme/changelog.md
@@ -1,6 +1,6 @@
 All notable changes to this project will be documented in this file.
 
-## 2.0.0 (TBD)
+## 2.0.0
 
 - `heat_index` now returns `{ hi: NaN }` by default when `tdb < 27 °C`, matching `pythermalcomfort` 3.9.3 `heat_index_rothfusz`. IP mode uses the equivalent threshold, `tdb < 80.6 °F`, so the same physical temperature is accepted or rejected regardless of unit system. This is a breaking change compared with previous versions; callers needing the previous behaviour should pass `{ limit_inputs: false }`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsthermalcomfort",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsthermalcomfort",
-      "version": "1.1.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "mathjs": "^15.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsthermalcomfort",
-  "version": "1.1.2",
+  "version": "1.3.0",
   "description": "A JavaScript package to calculate thermophysiological, thermal comfort, thermal stress indices",
   "type": "module",
   "files": [

--- a/src/models/heat_index.js
+++ b/src/models/heat_index.js
@@ -10,6 +10,11 @@ import { round, validateInputs } from "../utilities/utilities.js";
  * The HI equation {@link #ref_12|[12]} is derived by multiple regression analysis in temperature and relative humidity from the first version
  * of Steadman’s (1979) apparent temperature (AT) {@link #ref_13|[13]}.
  *
+ * The Rothfusz regression is only valid above 27 °C (80.6 °F). Under the
+ * default `limit_inputs=true` the function returns `{ hi: NaN }` when `tdb`
+ * is below this threshold; pass `limit_inputs=false` to compute regardless.
+ * Matches pythermalcomfort 3.9.3 `heat_index_rothfusz`.
+ *
  * @public
  * @memberof models
  * @docname Heat Index
@@ -19,11 +24,14 @@ import { round, validateInputs } from "../utilities/utilities.js";
  * @param {Object} [options] (Optional) Other parameters.
  * @param {boolean} [options.round=true] - If True rounds output value, if False it does not round it.
  * @param {"SI" | "IP"} [options.units="SI"] - Select the SI (International System of Units) or the IP (Imperial Units) system.
+ * @param {boolean} [options.limit_inputs=true] - If True (default), `tdb` below the Rothfusz applicability threshold (27 °C / 80.6 °F) returns `NaN`. If False, the regression is evaluated regardless of input range.
  *
  * @returns {HeatIndexResult} set containing results for the model
  *
  * @example
- * const hi = heat_index(25, 50); // returns {hi: 25.9}
+ * const hi = heat_index(25, 50); // returns {hi: NaN} (below 27 °C threshold)
+ * const hi2 = heat_index(25, 50, { limit_inputs: false }); // returns {hi: 25.9}
+ * const hi3 = heat_index(30, 80); // returns {hi: 37.7}
  *
  * @category Thermophysiological models
  */
@@ -32,14 +40,30 @@ const HEAT_INDEX_SCHEMA = {
   rh: { type: "number" },
   round: { type: "boolean", required: false },
   units: { enum: ["SI", "IP"], required: false },
+  limit_inputs: { type: "boolean", required: false },
 };
 
 export function heat_index(tdb, rh, options = { round: true, units: "SI" }) {
   if (options.units) options.units = options.units.toUpperCase();
   validateInputs(
-    { tdb, rh, round: options.round, units: options.units },
+    {
+      tdb,
+      rh,
+      round: options.round,
+      units: options.units,
+      limit_inputs: options.limit_inputs,
+    },
     HEAT_INDEX_SCHEMA,
   );
+
+  const limit_inputs = options.limit_inputs ?? true;
+  if (limit_inputs) {
+    const threshold = options.units === "IP" ? 80.6 : 27;
+    if (tdb < threshold) {
+      return { hi: NaN };
+    }
+  }
+
   let hi;
   let tdb_squared = Math.pow(tdb, 2);
   let rh_squared = Math.pow(rh, 2);

--- a/tests/models/heat_index.test.js
+++ b/tests/models/heat_index.test.js
@@ -1,7 +1,9 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { heat_index } from "../../src/models/heat_index";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // Import shared utilities
+
+// Validated against pythermalcomfort 3.9.3 heat_index_rothfusz.
 
 let returnArray = false;
 
@@ -15,7 +17,13 @@ describe("heat_index", () => {
   test.each(testData.data)("Test case #%#", (testCase) => {
     const { inputs, outputs: expectedOutput } = testCase;
     const { tdb, rh, options } = inputs;
-    const modelResult = heat_index(tdb, rh, options);
+    // Mirror pythermalcomfort's test harness which calls
+    // `heat_index_rothfusz(**inputs, limit_inputs=False)` so the shared
+    // fixture validates the Rothfusz formula independently of the gate.
+    const modelResult = heat_index(tdb, rh, {
+      ...options,
+      limit_inputs: false,
+    });
 
     validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
@@ -36,7 +44,53 @@ describe("heat_index input validation", () => {
     expect(() => heat_index(25, 50, { round: "true" })).toThrow(TypeError);
   });
 
+  test("throws TypeError if limit_inputs is not a boolean", () => {
+    expect(() => heat_index(30, 50, { limit_inputs: "true" })).toThrow(
+      TypeError,
+    );
+  });
+
   test("throws Error if units is not a valid enum", () => {
     expect(() => heat_index(25, 50, { units: "INVALID" })).toThrow(Error);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default-on Rothfusz applicability gate (tdb < 27 °C / 80.6 °F → NaN).
+// Matches pythermalcomfort 3.9.3 heat_index_rothfusz default behaviour.
+// ---------------------------------------------------------------------------
+describe("heat_index Rothfusz applicability gate", () => {
+  test.each([
+    ["SI tdb just below 27", 26.9, 50, undefined],
+    ["SI tdb well below 27", 20, 50, undefined],
+    ["SI tdb at 0", 0, 50, undefined],
+    ["IP tdb just below 80.6", 80.5, 50, "IP"],
+    ["IP tdb well below 80.6", 60, 50, "IP"],
+  ])("returns NaN under default limit_inputs when %s", (_, tdb, rh, units) => {
+    const result = heat_index(tdb, rh, units ? { units } : undefined);
+    expect(result.hi).toBeNaN();
+  });
+
+  test.each([
+    ["SI tdb at 27", 27, 50, undefined, true],
+    ["SI tdb above 27", 35, 80, undefined, true],
+    ["IP tdb at 80.6", 80.6, 50, "IP", true],
+    ["IP tdb above 80.6", 95, 50, "IP", true],
+  ])(
+    "returns a finite hi under default limit_inputs when %s",
+    (_, tdb, rh, units, _expectFinite) => {
+      const result = heat_index(tdb, rh, units ? { units } : undefined);
+      expect(Number.isFinite(result.hi)).toBe(true);
+    },
+  );
+
+  test("limit_inputs=false bypasses the gate and computes for tdb < 27 °C", () => {
+    const result = heat_index(25, 50, { limit_inputs: false });
+    expect(result.hi).toBe(25.9);
+  });
+
+  test("limit_inputs=false bypasses the gate in IP mode", () => {
+    const result = heat_index(70, 50, { units: "IP", limit_inputs: false });
+    expect(Number.isFinite(result.hi)).toBe(true);
   });
 });

--- a/tests/models/heat_index.test.js
+++ b/tests/models/heat_index.test.js
@@ -29,9 +29,6 @@ describe("heat_index", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Input validation tests
-// ---------------------------------------------------------------------------
 describe("heat_index input validation", () => {
   test.each([
     ["tdb", "25", 50],
@@ -55,10 +52,7 @@ describe("heat_index input validation", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Default-on Rothfusz applicability gate (tdb < 27 °C / 80.6 °F → NaN).
 // Matches pythermalcomfort 3.9.3 heat_index_rothfusz default behaviour.
-// ---------------------------------------------------------------------------
 describe("heat_index Rothfusz applicability gate", () => {
   test.each([
     ["SI tdb just below 27", 26.9, 50, undefined],


### PR DESCRIPTION
## What this PR does

- Adds `limit_inputs` option to `heat_index` (default `true`) gating `tdb` below the Rothfusz applicability threshold (27 °C / 80.6 °F) to `NaN`.
- Test harness now passes `limit_inputs: false` for fixture-driven cases, mirroring pythermalcomfort's `**inputs, limit_inputs=False` pattern. Existing two fixture rows (`tdb=25`, `tdb=30`) continue to validate the formula.
- New local describe block covers the gate (NaN below, finite at/above, bypass with `limit_inputs=false`) for both SI and IP units.

## Why this change is needed

- Part of #142 (input validation across all models).
- pythermalcomfort 3.9.3 `heat_index_rothfusz` gates `tdb < 27 °C` to `NaN` by default; this PR adds the same gate to jsthermalcomfort's `heat_index`.
- The #168 discussion treated `heat_index` `tdb < 27` as an applicability limit (not physical invalidity), so it sits in the `NaN` under `limit_inputs` category, not the `RangeError` category.

## How I tested it

- [x] `npm test`
- [x] `npm run build`

## Notes for reviewers

- **Breaking change**: `heat_index(tdb, rh)` where `tdb < 27 °C` now returns `{ hi: NaN }` under the default. Callers needing the previous behaviour should pass `{ limit_inputs: false }`. Marked with `feat!` and `BREAKING CHANGE` footer.
- Gate uses unit-direct thresholds (`SI < 27`, `IP < 80.6`) instead of internal IP→SI conversion. The conversion approach trips at the IP=80.6 boundary because `(80.6 - 32) * 5/9 = 26.999999999999996` in IEEE 754. Unit-direct gives a predictable threshold in the user's chosen units.
- [`validation-data-comfort-models#9`](https://github.com/FedericoTartarini/validation-data-comfort-models/pull/9) is related optional fixture coverage (six new tdb ≥ 27 reference rows), not a prerequisite. This PR works against the existing two-row fixture.
- No internal callers within jsthermalcomfort touch `heat_index` outside the public export, so impact is limited to external API users.