### PR TITLE
Harden test harness against silent-skip and fake-pass paths

### DIFF
--- a/tests/models/phs.test.js
+++ b/tests/models/phs.test.js
@@ -7,6 +7,8 @@ import {
   validateResult,
 } from "./testUtils.js";
 
+// Validated against pythermalcomfort 3.9.3.
+
 const testDataUrl = testDataUrls.phs;
 
 // Load data at module scope so test.each registers one test per row.

--- a/tests/models/phs.test.js
+++ b/tests/models/phs.test.js
@@ -1,94 +1,57 @@
-import { expect, describe, it, test, beforeAll } from "@jest/globals";
-import fetch from "node-fetch";
+import { expect, describe, test } from "@jest/globals";
 import { phs } from "../../src/models/phs";
 import { testDataUrls } from "./comftest"; // Import test URLs from comftest.js
+import { assertNonEmptyRows, loadTestData } from "./testUtils.js";
 
 const testDataUrl = testDataUrls.phs;
 
-let testData;
-let tolerance;
+// Load data at module scope so test.each registers one test per row.
+// loadTestData filters out array-input rows; the secondary filter below
+// also drops rows whose outputs are missing or contain arrays.
+const { testData, tolerances } = await loadTestData(testDataUrl, false);
 
-beforeAll(async () => {
-  try {
-    const response = await fetch(testDataUrl);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch test data: ${response.statusText}`);
-    }
-
-    testData = await response.json();
-    tolerance = testData.tolerance; // Retrieve tolerance from remote data
-  } catch (error) {
-    console.error("Unable to fetch or parse test data:", error);
-    throw error;
-  }
-});
+const scalarRows = assertNonEmptyRows(
+  testData.data.filter(({ outputs }) => {
+    if (outputs === undefined || outputs === null) return false;
+    return !Object.values(outputs).some((value) => Array.isArray(value));
+  }),
+  "phs scalar rows with finite outputs",
+);
 
 describe("phs", () => {
-  it("should run tests and skip data that contains arrays or undefined fields", () => {
-    if (!testData || !testData.data) {
-      throw new Error("Test data is not properly loaded");
+  test.each(scalarRows)("row #%#", ({ inputs, outputs }) => {
+    const result = phs(
+      inputs.tdb,
+      inputs.tr,
+      inputs.v,
+      inputs.rh,
+      inputs.met,
+      inputs.clo,
+      inputs.posture,
+      inputs.wme,
+      "7933-2004",
+      inputs,
+    );
+
+    // Per-key tolerances: d_lim accumulates float boundary crossings (+/- 1.5
+    // minute), sweat_loss_g / evap_load_wm2_min accumulate larger absolute
+    // error (+/- 10), sweat_rate_watt diverges by +/- 0.3 because JS uses
+    // half-up rounding while Python uses banker's rounding.
+    for (let [key, value] of Object.entries(outputs)) {
+      if (key.startsWith("d_lim")) {
+        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(1.5);
+      } else if (key === "sweat_loss_g" || key === "evap_load_wm2_min") {
+        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(10);
+      } else if (key === "sweat_rate_watt") {
+        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(0.3);
+      } else {
+        const tol =
+          tolerances && tolerances[key] !== undefined
+            ? tolerances[key]
+            : 0.0001;
+        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(tol);
+      }
     }
-
-    testData.data.forEach(({ inputs, outputs }) => {
-      // Check for arrays or undefined values in inputs or outputs
-      const hasArrayOrUndefined =
-        Object.values(inputs).some(
-          (value) => Array.isArray(value) || value === undefined,
-        ) || Object.values(outputs).some((value) => Array.isArray(value));
-
-      if (hasArrayOrUndefined || outputs === undefined) {
-        console.warn(
-          `Skipping test due to missing or invalid inputs/outputs: inputs=${JSON.stringify(
-            inputs,
-          )}`,
-        );
-        return;
-      }
-
-      let result;
-      try {
-        result = phs(
-          inputs.tdb,
-          inputs.tr,
-          inputs.v,
-          inputs.rh,
-          inputs.met,
-          inputs.clo,
-          inputs.posture,
-          inputs.wme,
-          "7933-2004",
-          inputs,
-        );
-
-        // Compare values with field-specific tolerance
-        for (let [key, value] of Object.entries(outputs)) {
-          if (key.startsWith("d_lim")) {
-            // Allow +/- 1.5 minute due to float accumulation boundary crossing
-            expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(1.5);
-          } else if (key === "sweat_loss_g" || key === "evap_load_wm2_min") {
-            // Allow +/- 10 grams / units due to float accumulation
-            expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(10);
-          } else if (key === "sweat_rate_watt") {
-            // Allow +/- 0.3 diff since JS uses half-up rounding (266.15 -> 266.2) vs Python banker's rounding (266.1)
-            expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(0.3);
-          } else {
-            // Use the specified tolerance if available, otherwise default to a strict 0.0001
-            const tol =
-              tolerance && tolerance[key] !== undefined
-                ? tolerance[key]
-                : 0.0001;
-            expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(tol);
-          }
-        }
-      } catch (error) {
-        console.error("Test failed with inputs:", inputs);
-        if (typeof result !== "undefined") {
-          console.error("Received result:", result);
-          console.error("Expected result:", outputs);
-        }
-        throw error; // Re-throw to display specific error details
-      }
-    });
   });
 });
 

--- a/tests/models/phs.test.js
+++ b/tests/models/phs.test.js
@@ -1,7 +1,11 @@
 import { expect, describe, test } from "@jest/globals";
 import { phs } from "../../src/models/phs";
 import { testDataUrls } from "./comftest"; // Import test URLs from comftest.js
-import { assertNonEmptyRows, loadTestData } from "./testUtils.js";
+import {
+  assertNonEmptyRows,
+  loadTestData,
+  validateResult,
+} from "./testUtils.js";
 
 const testDataUrl = testDataUrls.phs;
 
@@ -33,25 +37,24 @@ describe("phs", () => {
       inputs,
     );
 
-    // Per-key tolerances: d_lim accumulates float boundary crossings (+/- 1.5
-    // minute), sweat_loss_g / evap_load_wm2_min accumulate larger absolute
-    // error (+/- 10), sweat_rate_watt diverges by +/- 0.3 because JS uses
-    // half-up rounding while Python uses banker's rounding.
-    for (let [key, value] of Object.entries(outputs)) {
+    // Per-key tolerance overrides: d_lim* accumulates float-boundary
+    // crossings (+/- 1.5 minute), sweat_loss_g / evap_load_wm2_min
+    // accumulate larger absolute error (+/- 10), sweat_rate_watt diverges
+    // by +/- 0.3 because JS uses half-up rounding while Python uses
+    // banker's rounding. Build a per-row tolerance map so validateResult
+    // applies the correct tolerance for each output key.
+    const perRowTolerances = { ...(tolerances ?? {}) };
+    for (const key of Object.keys(outputs)) {
       if (key.startsWith("d_lim")) {
-        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(1.5);
+        perRowTolerances[key] = 1.5;
       } else if (key === "sweat_loss_g" || key === "evap_load_wm2_min") {
-        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(10);
+        perRowTolerances[key] = 10;
       } else if (key === "sweat_rate_watt") {
-        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(0.3);
-      } else {
-        const tol =
-          tolerances && tolerances[key] !== undefined
-            ? tolerances[key]
-            : 0.0001;
-        expect(Math.abs(result[key] - value)).toBeLessThanOrEqual(tol);
+        perRowTolerances[key] = 0.3;
       }
     }
+
+    validateResult(result, outputs, perRowTolerances, inputs);
   });
 });
 

--- a/tests/models/pmv_ppd_ashrae.test.js
+++ b/tests/models/pmv_ppd_ashrae.test.js
@@ -3,18 +3,25 @@
 import { describe, expect, test } from "@jest/globals";
 import { pmv_ppd_ashrae } from "../../src/models/pmv_ppd_ashrae.js";
 import { testDataUrls } from "./comftest";
-import { loadTestData, validateResult } from "./testUtils.js";
+import {
+  assertNonEmptyRows,
+  loadTestData,
+  validateResult,
+} from "./testUtils.js";
 
 // Load test data from the shared repository (filters out array-input rows).
 let { testData, tolerances } = await loadTestData(testDataUrls.pmvPpd, false);
 
 // Keep only scalar SI ASHRAE rows.
-const ashraeData = testData.data.filter((testCase) => {
-  const { standard, units } = testCase.inputs;
-  const isAshrae = standard === "ASHRAE";
-  const isSI = !units || units.toLowerCase() === "si";
-  return isAshrae && isSI;
-});
+const ashraeData = assertNonEmptyRows(
+  testData.data.filter((testCase) => {
+    const { standard, units } = testCase.inputs;
+    const isAshrae = standard === "ASHRAE";
+    const isSI = !units || units.toLowerCase() === "si";
+    return isAshrae && isSI;
+  }),
+  "pmv_ppd_ashrae scalar SI ASHRAE rows",
+);
 
 describe("pmv_ppd_ashrae", () => {
   test.each(ashraeData)("ASHRAE test case #%#", (testCase) => {

--- a/tests/models/pmv_ppd_iso.test.js
+++ b/tests/models/pmv_ppd_iso.test.js
@@ -3,18 +3,25 @@
 import { describe, expect, test } from "@jest/globals";
 import { pmv_ppd_iso } from "../../src/models/pmv_ppd_iso.js";
 import { testDataUrls } from "./comftest";
-import { loadTestData, validateResult } from "./testUtils.js";
+import {
+  assertNonEmptyRows,
+  loadTestData,
+  validateResult,
+} from "./testUtils.js";
 
 // Load test data from the shared repository (filters out array-input rows).
 let { testData, tolerances } = await loadTestData(testDataUrls.pmvPpd, false);
 
 // Keep only scalar SI ISO rows.
-const isoData = testData.data.filter((testCase) => {
-  const { standard, units } = testCase.inputs;
-  const isISO = standard === "ISO";
-  const isSI = !units || units.toLowerCase() === "si";
-  return isISO && isSI;
-});
+const isoData = assertNonEmptyRows(
+  testData.data.filter((testCase) => {
+    const { standard, units } = testCase.inputs;
+    const isISO = standard === "ISO";
+    const isSI = !units || units.toLowerCase() === "si";
+    return isISO && isSI;
+  }),
+  "pmv_ppd_iso scalar SI ISO rows",
+);
 
 describe("pmv_ppd_iso", () => {
   test.each(isoData)("ISO test case #%#", (testCase) => {

--- a/tests/models/testUtils.js
+++ b/tests/models/testUtils.js
@@ -1,5 +1,18 @@
 import fetch from "node-fetch"; // Import node-fetch to support data fetching
 
+/**
+ * Drop rows whose `inputs` contain any array-valued field. Pure helper so it
+ * can be unit-tested without a network round trip.
+ *
+ * @param {Array<{ inputs: Object }>} rows
+ * @returns {Array}
+ */
+export function filterScalarRows(rows) {
+  return rows.filter((row) =>
+    Object.values(row.inputs).every((value) => !Array.isArray(value)),
+  );
+}
+
 // Load test data and extract tolerance
 export async function loadTestData(url, returnArray = false) {
   let testData;
@@ -18,11 +31,15 @@ export async function loadTestData(url, returnArray = false) {
 
   // If returnArray is false, filter out test cases that have array inputs.
   if (!returnArray && Array.isArray(testData.data)) {
-    testData.data = testData.data.filter((testCase) => {
-      return Object.values(testCase.inputs).every(
-        (value) => !Array.isArray(value),
+    testData.data = filterScalarRows(testData.data);
+    // Surface a silent-skip: callers iterate `testData.data`, so an empty
+    // dataset registers zero tests yet reports green.
+    if (testData.data.length === 0) {
+      throw new Error(
+        `loadTestData: 0 scalar rows after filtering (url=${url}). ` +
+          `Pass returnArray=true if the dataset is array-valued.`,
       );
-    });
+    }
   }
   return { testData, tolerances };
 }
@@ -48,8 +65,34 @@ export function validateResult(
   tolerances,
   inputs,
 ) {
+  // Silent-skip guards. Without these, an empty/missing `expectedOutputs`
+  // makes Object.keys(...).forEach run zero assertions and the test reports
+  // green. A null/undefined `modelResult` against non-empty expectations is
+  // also treated as a hard failure rather than letting the property access
+  // throw mid-loop with a confusing TypeError.
+  if (
+    expectedOutputs === null ||
+    expectedOutputs === undefined ||
+    typeof expectedOutputs !== "object"
+  ) {
+    throw new Error(
+      "validateResult: expectedOutputs must be a non-null object.",
+    );
+  }
+  const expectedKeys = Object.keys(expectedOutputs);
+  if (expectedKeys.length === 0) {
+    throw new Error(
+      "validateResult: expectedOutputs is empty; refusing to run zero assertions.",
+    );
+  }
+  if (modelResult === null || modelResult === undefined) {
+    throw new Error(
+      "validateResult: modelResult is null/undefined but expectedOutputs has keys.",
+    );
+  }
+
   try {
-    Object.keys(expectedOutputs).forEach((key) => {
+    expectedKeys.forEach((key) => {
       const expectedValue =
         expectedOutputs[key] === null ? NaN : expectedOutputs[key];
       const actualValue = modelResult[key];
@@ -61,6 +104,9 @@ export function validateResult(
       // Handle arrays
       if (Array.isArray(expectedValue)) {
         expect(Array.isArray(actualValue)).toBe(true);
+        // Length check guards against the silent-skip where a longer actual
+        // array slips trailing elements past the per-index loop.
+        expect(actualValue).toHaveLength(expectedValue.length);
         expectedValue.forEach((exp, index) => {
           const act = actualValue[index];
           if (typeof exp === "number") {

--- a/tests/models/testUtils.js
+++ b/tests/models/testUtils.js
@@ -13,6 +13,26 @@ export function filterScalarRows(rows) {
   );
 }
 
+/**
+ * Throw if the supplied row set is empty. Callers that filter the dataset
+ * after `loadTestData` (e.g. by standard, by units) can wrap their result in
+ * this helper so a fixture drift that empties the filter shows up as a hard
+ * failure rather than a silent `test.each([])` that registers zero row tests.
+ *
+ * @param {Array} rows
+ * @param {string} label - human-readable description for the error message
+ * @returns {Array} the same rows, unchanged, when non-empty
+ */
+export function assertNonEmptyRows(rows, label) {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    throw new Error(
+      `${label}: 0 rows after filtering. ` +
+        `test.each([]) would register zero tests and report green.`,
+    );
+  }
+  return rows;
+}
+
 // Load test data and extract tolerance
 export async function loadTestData(url, returnArray = false) {
   let testData;
@@ -30,16 +50,14 @@ export async function loadTestData(url, returnArray = false) {
   }
 
   // If returnArray is false, filter out test cases that have array inputs.
+  // Callers iterate `testData.data`, so an empty dataset would register
+  // zero tests yet report green; assertNonEmptyRows turns that into a hard
+  // failure with a descriptive message.
   if (!returnArray && Array.isArray(testData.data)) {
-    testData.data = filterScalarRows(testData.data);
-    // Surface a silent-skip: callers iterate `testData.data`, so an empty
-    // dataset registers zero tests yet reports green.
-    if (testData.data.length === 0) {
-      throw new Error(
-        `loadTestData: 0 scalar rows after filtering (url=${url}). ` +
-          `Pass returnArray=true if the dataset is array-valued.`,
-      );
-    }
+    testData.data = assertNonEmptyRows(
+      filterScalarRows(testData.data),
+      `loadTestData scalar filter (url=${url})`,
+    );
   }
   return { testData, tolerances };
 }

--- a/tests/models/testUtils.js
+++ b/tests/models/testUtils.js
@@ -125,6 +125,10 @@ export function validateResult(
             if (isNaN(exp)) {
               expect(act).toBeNaN();
             } else {
+              // typeof guard prevents JS coercion false-passes:
+              // null - 0, false - 0, [] - 0, "1" - 1 all evaluate to a
+              // tolerable difference in plain Math.abs comparison.
+              expect(typeof act).toBe("number");
               expect(Math.abs(act - exp)).toBeLessThanOrEqual(
                 tol + Number.EPSILON * 100,
               );
@@ -138,6 +142,8 @@ export function validateResult(
         if (isNaN(expectedValue)) {
           expect(actualValue).toBeNaN();
         } else {
+          // typeof guard prevents JS coercion false-passes (see array branch).
+          expect(typeof actualValue).toBe("number");
           expect(Math.abs(actualValue - expectedValue)).toBeLessThanOrEqual(
             tol + Number.EPSILON * 100,
           );

--- a/tests/models/testUtils.js
+++ b/tests/models/testUtils.js
@@ -62,12 +62,6 @@ export async function loadTestData(url, returnArray = false) {
   return { testData, tolerances };
 }
 
-// Check if the test should be skipped (if it contains array data)
-export function shouldSkipTest(inputs) {
-  const values = Object.values(inputs);
-  return values.some((value) => Array.isArray(value));
-}
-
 /**
  * Validates the model's output against the expected outputs using specified tolerances.
  *

--- a/tests/models/testUtils.test.js
+++ b/tests/models/testUtils.test.js
@@ -6,39 +6,70 @@
 // `expect.hasAssertions()` so the meta-tests cannot themselves silent-skip
 // with zero effective assertions.
 
-import { describe, expect, test } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
 import {
   validateResult,
   filterScalarRows,
   assertNonEmptyRows,
 } from "./testUtils.js";
 
+// validateResult logs failure context via console.log inside its catch
+// block. Meta-tests deliberately trigger throws to verify behaviour, so
+// silence the log spam here. Real model test failures still surface the
+// context because they run with the unmocked console.
+beforeEach(() => {
+  jest.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 describe("validateResult — silent-skip guards", () => {
+  // The toThrow regexes match the specific guard messages, not just any
+  // throw. Without that, a regression where the guard is removed and the
+  // function falls back to a generic TypeError (e.g. Object.keys(null))
+  // would still pass these tests.
   test("throws when expectedOutputs is an empty object", () => {
     expect.hasAssertions();
-    // Without a guard, Object.keys({}).forEach runs zero assertions and
-    // validateResult returns silently — the canonical silent-skip path.
-    expect(() => validateResult({ a: 1 }, {}, {}, {})).toThrow();
+    expect(() => validateResult({ a: 1 }, {}, {}, {})).toThrow(
+      /expectedOutputs is empty/,
+    );
   });
 
   test("throws when expectedOutputs is null", () => {
     expect.hasAssertions();
-    expect(() => validateResult({ a: 1 }, null, {}, {})).toThrow();
+    expect(() => validateResult({ a: 1 }, null, {}, {})).toThrow(
+      /expectedOutputs must be a non-null object/,
+    );
   });
 
   test("throws when expectedOutputs is undefined", () => {
     expect.hasAssertions();
-    expect(() => validateResult({ a: 1 }, undefined, {}, {})).toThrow();
+    expect(() => validateResult({ a: 1 }, undefined, {}, {})).toThrow(
+      /expectedOutputs must be a non-null object/,
+    );
   });
 
   test("throws when modelResult is null but expectedOutputs is non-empty", () => {
     expect.hasAssertions();
-    expect(() => validateResult(null, { a: 1 }, {}, {})).toThrow();
+    expect(() => validateResult(null, { a: 1 }, {}, {})).toThrow(
+      /modelResult is null\/undefined/,
+    );
   });
 
   test("throws when modelResult is undefined but expectedOutputs is non-empty", () => {
     expect.hasAssertions();
-    expect(() => validateResult(undefined, { a: 1 }, {}, {})).toThrow();
+    expect(() => validateResult(undefined, { a: 1 }, {}, {})).toThrow(
+      /modelResult is null\/undefined/,
+    );
   });
 });
 

--- a/tests/models/testUtils.test.js
+++ b/tests/models/testUtils.test.js
@@ -9,7 +9,6 @@
 import { describe, expect, test } from "@jest/globals";
 import {
   validateResult,
-  shouldSkipTest,
   filterScalarRows,
   assertNonEmptyRows,
 } from "./testUtils.js";
@@ -153,29 +152,6 @@ describe("validateResult — non-numeric comparison", () => {
     expect(() =>
       validateResult({ a: "strong" }, { a: "moderate" }, {}, {}),
     ).toThrow();
-  });
-});
-
-describe("shouldSkipTest", () => {
-  test("returns true when any value is an array", () => {
-    expect.hasAssertions();
-    expect(shouldSkipTest({ tdb: 25, v: [0.1, 0.2] })).toBe(true);
-  });
-
-  test("returns true when all values are arrays", () => {
-    expect.hasAssertions();
-    expect(shouldSkipTest({ tdb: [25, 26], v: [0.1, 0.2] })).toBe(true);
-  });
-
-  test("returns false when all values are scalar", () => {
-    expect.hasAssertions();
-    expect(shouldSkipTest({ tdb: 25, rh: 50, v: 0.1 })).toBe(false);
-  });
-
-  test("returns false for empty inputs object", () => {
-    expect.hasAssertions();
-    // No values means no array values; the predicate is vacuously false.
-    expect(shouldSkipTest({})).toBe(false);
   });
 });
 

--- a/tests/models/testUtils.test.js
+++ b/tests/models/testUtils.test.js
@@ -11,6 +11,7 @@ import {
   validateResult,
   shouldSkipTest,
   filterScalarRows,
+  assertNonEmptyRows,
 } from "./testUtils.js";
 
 describe("validateResult — silent-skip guards", () => {
@@ -206,5 +207,28 @@ describe("filterScalarRows", () => {
       { inputs: { rh: [50, 60] }, outputs: { x: 2 } },
     ];
     expect(filterScalarRows(rows)).toEqual([]);
+  });
+});
+
+describe("assertNonEmptyRows", () => {
+  test("returns the rows unchanged when non-empty", () => {
+    expect.hasAssertions();
+    const rows = [{ inputs: { tdb: 25 } }];
+    expect(assertNonEmptyRows(rows, "label")).toBe(rows);
+  });
+
+  test("throws when the array is empty (post-filter silent-skip guard)", () => {
+    expect.hasAssertions();
+    // This is the path callers like pmv_ppd_ashrae.test.js / two_nodes.test.js
+    // depend on: a fixture-drift filter that yields zero rows would otherwise
+    // hand `test.each([])` an empty list and report green.
+    expect(() => assertNonEmptyRows([], "pmv_ppd_ashrae rows")).toThrow(
+      /pmv_ppd_ashrae rows/,
+    );
+  });
+
+  test("throws when input is not an array", () => {
+    expect.hasAssertions();
+    expect(() => assertNonEmptyRows(undefined, "label")).toThrow();
   });
 });

--- a/tests/models/testUtils.test.js
+++ b/tests/models/testUtils.test.js
@@ -83,6 +83,30 @@ describe("validateResult — numeric comparison", () => {
     expect.hasAssertions();
     expect(() => validateResult({ a: NaN }, { a: 1.0 }, {}, {})).toThrow();
   });
+
+  // JS coercion guards: null, false, numeric strings, and empty arrays all
+  // arithmetically subtract to 0 in JavaScript, so a plain Math.abs check
+  // against an expected 0/1 would silently pass. The typeof guard ensures
+  // these values fail loudly.
+  test("throws when expected is finite but actual is null (no coercion)", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: null }, { a: 0 }, {}, {})).toThrow();
+  });
+
+  test("throws when expected is finite but actual is false (no coercion)", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: false }, { a: 0 }, {}, {})).toThrow();
+  });
+
+  test("throws when expected is finite but actual is a numeric string", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: "1" }, { a: 1 }, {}, {})).toThrow();
+  });
+
+  test("throws when expected is finite but actual is an empty array", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: [] }, { a: 0 }, {}, {})).toThrow();
+  });
 });
 
 describe("validateResult — array comparison", () => {

--- a/tests/models/testUtils.test.js
+++ b/tests/models/testUtils.test.js
@@ -1,0 +1,210 @@
+// Meta-tests for the shared validation harness in `testUtils.js`.
+//
+// These tests target the harness itself, not any model. They guard against
+// the silent-skip class of bugs raised in Week 9 §一: a test wrapper that
+// runs zero assertions yet reports green. Each case uses
+// `expect.hasAssertions()` so the meta-tests cannot themselves silent-skip
+// with zero effective assertions.
+
+import { describe, expect, test } from "@jest/globals";
+import {
+  validateResult,
+  shouldSkipTest,
+  filterScalarRows,
+} from "./testUtils.js";
+
+describe("validateResult — silent-skip guards", () => {
+  test("throws when expectedOutputs is an empty object", () => {
+    expect.hasAssertions();
+    // Without a guard, Object.keys({}).forEach runs zero assertions and
+    // validateResult returns silently — the canonical silent-skip path.
+    expect(() => validateResult({ a: 1 }, {}, {}, {})).toThrow();
+  });
+
+  test("throws when expectedOutputs is null", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: 1 }, null, {}, {})).toThrow();
+  });
+
+  test("throws when expectedOutputs is undefined", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: 1 }, undefined, {}, {})).toThrow();
+  });
+
+  test("throws when modelResult is null but expectedOutputs is non-empty", () => {
+    expect.hasAssertions();
+    expect(() => validateResult(null, { a: 1 }, {}, {})).toThrow();
+  });
+
+  test("throws when modelResult is undefined but expectedOutputs is non-empty", () => {
+    expect.hasAssertions();
+    expect(() => validateResult(undefined, { a: 1 }, {}, {})).toThrow();
+  });
+});
+
+describe("validateResult — numeric comparison", () => {
+  test("passes when actual is within tolerance", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult({ a: 1.0001 }, { a: 1.0 }, { a: 0.001 }, {}),
+    ).not.toThrow();
+  });
+
+  test("throws when actual exceeds tolerance", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult({ a: 1.01 }, { a: 1.0 }, { a: 0.001 }, {}),
+    ).toThrow();
+  });
+
+  test("falls back to default tolerance 0.0001 when tolerances is missing", () => {
+    expect.hasAssertions();
+    // Within default tolerance — passes.
+    expect(() =>
+      validateResult({ a: 1.00005 }, { a: 1.0 }, undefined, {}),
+    ).not.toThrow();
+    // Outside default tolerance — throws.
+    expect(() =>
+      validateResult({ a: 1.001 }, { a: 1.0 }, undefined, {}),
+    ).toThrow();
+  });
+
+  test("treats null in expectedOutputs as NaN and matches NaN actual", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: NaN }, { a: null }, {}, {})).not.toThrow();
+  });
+
+  test("throws when expected is NaN but actual is finite", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: 1.0 }, { a: NaN }, {}, {})).toThrow();
+  });
+
+  test("throws when expected is finite but actual is NaN", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: NaN }, { a: 1.0 }, {}, {})).toThrow();
+  });
+});
+
+describe("validateResult — array comparison", () => {
+  test("passes element-wise within tolerance", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult(
+        { a: [1.0001, 2.0001] },
+        { a: [1.0, 2.0] },
+        { a: 0.001 },
+        {},
+      ),
+    ).not.toThrow();
+  });
+
+  test("throws when actual is shorter than expected", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult({ a: [1.0] }, { a: [1.0, 2.0] }, { a: 0.001 }, {}),
+    ).toThrow();
+  });
+
+  test("throws when actual is longer than expected (silent-skip guard)", () => {
+    expect.hasAssertions();
+    // Without an explicit length check, extra trailing elements are not
+    // asserted against, so a wrong-length output slips past silently.
+    expect(() =>
+      validateResult(
+        { a: [1.0, 2.0, 999.0] },
+        { a: [1.0, 2.0] },
+        { a: 0.001 },
+        {},
+      ),
+    ).toThrow();
+  });
+
+  test("throws when actual is not an array but expected is", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult({ a: 1.0 }, { a: [1.0] }, { a: 0.001 }, {}),
+    ).toThrow();
+  });
+});
+
+describe("validateResult — non-numeric comparison", () => {
+  test("passes when boolean values match", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult({ a: true }, { a: true }, {}, {}),
+    ).not.toThrow();
+  });
+
+  test("throws when boolean values differ", () => {
+    expect.hasAssertions();
+    expect(() => validateResult({ a: false }, { a: true }, {}, {})).toThrow();
+  });
+
+  test("passes when string values match", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult({ a: "moderate" }, { a: "moderate" }, {}, {}),
+    ).not.toThrow();
+  });
+
+  test("throws when string values differ", () => {
+    expect.hasAssertions();
+    expect(() =>
+      validateResult({ a: "strong" }, { a: "moderate" }, {}, {}),
+    ).toThrow();
+  });
+});
+
+describe("shouldSkipTest", () => {
+  test("returns true when any value is an array", () => {
+    expect.hasAssertions();
+    expect(shouldSkipTest({ tdb: 25, v: [0.1, 0.2] })).toBe(true);
+  });
+
+  test("returns true when all values are arrays", () => {
+    expect.hasAssertions();
+    expect(shouldSkipTest({ tdb: [25, 26], v: [0.1, 0.2] })).toBe(true);
+  });
+
+  test("returns false when all values are scalar", () => {
+    expect.hasAssertions();
+    expect(shouldSkipTest({ tdb: 25, rh: 50, v: 0.1 })).toBe(false);
+  });
+
+  test("returns false for empty inputs object", () => {
+    expect.hasAssertions();
+    // No values means no array values; the predicate is vacuously false.
+    expect(shouldSkipTest({})).toBe(false);
+  });
+});
+
+describe("filterScalarRows", () => {
+  test("keeps rows whose inputs are all scalar", () => {
+    expect.hasAssertions();
+    const rows = [
+      { inputs: { tdb: 25, rh: 50 }, outputs: { x: 1 } },
+      { inputs: { tdb: 26, rh: 60 }, outputs: { x: 2 } },
+    ];
+    expect(filterScalarRows(rows)).toHaveLength(2);
+  });
+
+  test("drops rows containing any array input", () => {
+    expect.hasAssertions();
+    const rows = [
+      { inputs: { tdb: 25, rh: 50 }, outputs: { x: 1 } },
+      { inputs: { tdb: [25, 26], rh: 50 }, outputs: { x: 2 } },
+    ];
+    const kept = filterScalarRows(rows);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].inputs.tdb).toBe(25);
+  });
+
+  test("returns empty array when every row has array inputs", () => {
+    expect.hasAssertions();
+    const rows = [
+      { inputs: { tdb: [25, 26] }, outputs: { x: 1 } },
+      { inputs: { rh: [50, 60] }, outputs: { x: 2 } },
+    ];
+    expect(filterScalarRows(rows)).toEqual([]);
+  });
+});

--- a/tests/models/two_nodes.test.js
+++ b/tests/models/two_nodes.test.js
@@ -1,5 +1,5 @@
 import { expect, describe, test, it } from "@jest/globals";
-import { loadTestData, validateResult } from "./testUtils";
+import { assertNonEmptyRows, loadTestData, validateResult } from "./testUtils";
 import { two_nodes } from "../../src/models/two_nodes";
 import { testDataUrls } from "./comftest"; // Import all test URLs from comftest.js
 
@@ -11,12 +11,15 @@ const { testData, tolerances } = await loadTestData(testDataUrl, false);
 
 // Skip rows with missing outputs or array-valued inputs; keep original
 // dataset index so failures are reported as "row N" matching the JSON file.
-const scalarRows = testData.data
-  .map((row, index) => ({ ...row, index }))
-  .filter(({ inputs, outputs }) => {
-    if (outputs === undefined || outputs === null) return false;
-    return !Object.values(inputs).some((value) => Array.isArray(value));
-  });
+const scalarRows = assertNonEmptyRows(
+  testData.data
+    .map((row, index) => ({ ...row, index }))
+    .filter(({ inputs, outputs }) => {
+      if (outputs === undefined || outputs === null) return false;
+      return !Object.values(inputs).some((value) => Array.isArray(value));
+    }),
+  "two_nodes scalar rows with outputs",
+);
 
 describe("two_nodes related tests", () => {
   test.each(scalarRows)("row $index", ({ inputs, outputs }) => {

--- a/tests/models/wbgt.test.js
+++ b/tests/models/wbgt.test.js
@@ -21,12 +21,9 @@ describe("wbgt", () => {
   });
 
   it("should throw an error when with_solar_load is set and tdb is not provided", () => {
-    try {
-      wbgt(0, 0, { with_solar_load: true });
-    } catch (error) {
-      // Verify specific error message
-      expect(error.message).toBe("Please enter the dry bulb air temperature");
-    }
+    expect(() => wbgt(0, 0, { with_solar_load: true })).toThrow(
+      "Please enter the dry bulb air temperature",
+    );
   });
 
   it("round_output:true returns value rounded to 1 decimal place", () => {


### PR DESCRIPTION
## What this PR does

- Guards `validateResult` against silent-skip paths: throws when `expectedOutputs` is empty / null / undefined, when `modelResult` is null / undefined, and when actual array length exceeds expected length.
- Adds a `typeof === "number"` check before numeric tolerance comparison to block JS coercion fake-passes. Without it, `null - 0`, `false - 0`, `"1" - 1`, and `[] - 0` all evaluate to a tolerable difference under bare `Math.abs`.
- Adds `assertNonEmptyRows(rows, label)` helper. `loadTestData` uses it on its scalar filter; `pmv_ppd_ashrae`, `pmv_ppd_iso`, and `two_nodes` use it on their secondary post-filter. Closes the path where a `test.each([])` registered zero row tests yet reported green.
- Migrates `phs.test.js` from `forEach`-inside-single-`it` to `test.each` + `validateResult`, inheriting the wrapper guards. Per-key tolerance overrides for `d_lim*`, `sweat_loss_g`, `evap_load_wm2_min`, and `sweat_rate_watt` are preserved by merging into a per-row tolerance map.
- Replaces the `try/catch` zero-assertion test in `wbgt.test.js` with `expect(() => ...).toThrow(message)`.
- Removes unused `shouldSkipTest` export (zero call sites).
- Adds 29 meta-tests in `tests/models/testUtils.test.js` covering each guard. Silent-skip guard tests bind `toThrow` to specific guard messages via regex so a regression that throws for unrelated reasons still fails the test. Every meta-test uses `expect.hasAssertions()` so the meta-tests cannot themselves silent-skip.

## Why this change is needed

Several test files passed green even when they ran zero assertions, or compared values whose JavaScript subtraction silently coerced to a tolerable number. The shared validation harness is the single mediator for every model test, so hardening it raises the assertion bar across the suite without rewriting individual model tests.

## How I tested it

- [x] `npm test`: 69 suites / 2188 tests (was 68 / 2150)
- [x] `npm run build`
- [x] Pre-commit hook (prettier check + build + jest) on each of the 8 commits

## Notes for reviewers

- Suite count goes up by 1 (new meta-test file). Test count goes up by 38: meta-tests +29, phs row tests +9 (a single `it` running 10 rows internally exploded into per-row `test.each` entries).
- The meta-tests deliberately trigger throws to verify behaviour. `validateResult` logs failure context via `console.log` inside its catch block, so the meta-test file silences that with `jest.spyOn(console, "log")` to keep CI output clean. Real model failures are unaffected.
- Three follow-ups deferred to separate PRs:
  - `tests/test_utilities.js`: `deep_close_to_obj` and `deep_close_to_array` use bare `Math.abs` and have no length parity check.
  - `tests/models/JOS3.test.js`: `Object.entries(fixture)` dynamically registers `it` blocks; an empty fixture would register zero.
  - `tests/models/validate.test.js`: 8 cases fully redundant with the new meta-test suite. Kept here to preserve a clean test-count delta on this PR.