### PR TITLE
fix(phs): make compliance check model-aware for ISO 7933:2004 and 2023

### DIFF
--- a/src/models/phs.js
+++ b/src/models/phs.js
@@ -217,11 +217,18 @@ export function phs(
   const met_watt = met * MET_WATT_PER_MET;
   const wme_watt = wme * MET_WATT_PER_MET;
 
-  const warnings = check_standard_compliance("ISO7933", {
+  let p_a;
+  if (model === "7933-2023") {
+    p_a = 0.6105 * Math.exp((17.27 * tdb) / (tdb + 237.3)) * (rh / 100);
+  } else {
+    p_a = ((p_sat(tdb) / 1000) * rh) / 100;
+  }
+
+  const warnings = check_standard_compliance(model, {
     tdb,
     tr,
     v,
-    rh,
+    p_a,
     met: met_watt * body_surface_area(joint_kwargs.weight, joint_kwargs.height),
     clo,
   });
@@ -240,13 +247,6 @@ export function phs(
       sweat_loss_g: NaN,
       evap_load_wm2_min: NaN,
     };
-  }
-
-  let p_a;
-  if (model === "7933-2023") {
-    p_a = 0.6105 * Math.exp((17.27 * tdb) / (tdb + 237.3)) * (rh / 100);
-  } else {
-    p_a = ((p_sat(tdb) / 1000) * rh) / 100;
   }
 
   const variables_for_loop = _calculate_variables_for_loop(

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -71,7 +71,19 @@ export function transpose_sharp_altitude(sharp, altitude) {
  */
 
 /**
- * @typedef {"ANKLE_DRAFT" | "ASHRAE" | "FAN_HEATWAVES" | "ISO" | "7933-2004" | "7933-2023"} Standard
+ * Standard names accepted by {@link check_standard_compliance}.
+ */
+export const Standard = Object.freeze({
+  ANKLE_DRAFT: "ANKLE_DRAFT",
+  ASHRAE: "ASHRAE",
+  FAN_HEATWAVES: "FAN_HEATWAVES",
+  ISO: "ISO",
+  ISO_7933_2004: "7933-2004",
+  ISO_7933_2023: "7933-2023",
+});
+
+/**
+ * @typedef {(typeof Standard)[keyof typeof Standard]} Standard
  */
 
 /**
@@ -84,17 +96,17 @@ export function transpose_sharp_altitude(sharp, altitude) {
  */
 export function check_standard_compliance(standard, kwargs) {
   switch (standard) {
-    case "ANKLE_DRAFT":
+    case Standard.ANKLE_DRAFT:
       return _ankle_draft_compliance(kwargs);
-    case "ASHRAE":
+    case Standard.ASHRAE:
       return _ashrae_compliance(kwargs);
-    case "FAN_HEATWAVES":
+    case Standard.FAN_HEATWAVES:
       return _fan_heatwaves_compliance(kwargs);
-    case "ISO":
+    case Standard.ISO:
       return _iso_compliance(kwargs);
-    case "7933-2004":
+    case Standard.ISO_7933_2004:
       return _iso7933_2004_compliance(kwargs);
-    case "7933-2023":
+    case Standard.ISO_7933_2023:
       return _iso7933_2023_compliance(kwargs);
     default:
       throw new Error("Unknown standard");

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -71,7 +71,7 @@ export function transpose_sharp_altitude(sharp, altitude) {
  */
 
 /**
- * @typedef {"ANKLE_DRAFT" | "ASHRAE" | "FAN_HEATWAVES" | "ISO" | "ISO7933"} Standard
+ * @typedef {"ANKLE_DRAFT" | "ASHRAE" | "FAN_HEATWAVES" | "ISO" | "7933-2004" | "7933-2023"} Standard
  */
 
 /**
@@ -92,8 +92,10 @@ export function check_standard_compliance(standard, kwargs) {
       return _fan_heatwaves_compliance(kwargs);
     case "ISO":
       return _iso_compliance(kwargs);
-    case "ISO7933":
-      return _iso7933_compliance(kwargs);
+    case "7933-2004":
+      return _iso7933_2004_compliance(kwargs);
+    case "7933-2023":
+      return _iso7933_2023_compliance(kwargs);
     default:
       throw new Error("Unknown standard");
   }
@@ -275,17 +277,18 @@ function _iso_compliance(kwargs) {
  *
  * @returns {string[]} strings with warnings emitted
  */
-function _iso7933_compliance(kwargs) {
+function _iso7933_2004_compliance(kwargs) {
+  // based on ISO 7933:2004 Annex A
   if (
     kwargs.tdb === undefined ||
-    kwargs.rh === undefined ||
+    kwargs.p_a === undefined ||
     kwargs.tr === undefined ||
     kwargs.v === undefined ||
     kwargs.met === undefined ||
     kwargs.clo === undefined
   ) {
     throw new Error(
-      `Missing arguments for ISO7933 compliance check, got: ${kwargs} and requires tdb, rh, tr, v, met and clo`,
+      `Missing arguments for ISO 7933:2004 compliance check, got: ${kwargs} and requires tdb, p_a, tr, v, met and clo`,
     );
   }
   /** @type {string[]} */
@@ -295,11 +298,7 @@ function _iso7933_compliance(kwargs) {
     warnings.push(
       "ISO 7933:2004 air temperature applicability limits between 15 and 50 ºC",
     );
-
-  const p_sat_result = p_sat(kwargs.tdb);
-  const p_a = ((p_sat_result / 1000) * kwargs.rh) / 100;
-
-  if (p_a > 4.5 || p_a < 0)
+  if (kwargs.p_a > 4.5 || kwargs.p_a < 0)
     warnings.push(
       "ISO 7933:2004 p_a applicability limits between 0 and 4.5 kPa",
     );
@@ -316,6 +315,48 @@ function _iso7933_compliance(kwargs) {
   if (kwargs.clo > 1 || kwargs.clo < 0.1)
     warnings.push(
       "ISO 7933:2004 clo applicability limits between 0.1 and 1 clo",
+    );
+  return warnings;
+}
+
+function _iso7933_2023_compliance(kwargs) {
+  // based on ISO 7933:2023 Annex A
+  if (
+    kwargs.tdb === undefined ||
+    kwargs.p_a === undefined ||
+    kwargs.tr === undefined ||
+    kwargs.v === undefined ||
+    kwargs.met === undefined ||
+    kwargs.clo === undefined
+  ) {
+    throw new Error(
+      `Missing arguments for ISO 7933:2023 compliance check, got: ${kwargs} and requires tdb, p_a, tr, v, met and clo`,
+    );
+  }
+  /** @type {string[]} */
+  let warnings = [];
+
+  if (kwargs.tdb > 50 || kwargs.tdb < 15)
+    warnings.push(
+      "ISO 7933:2023 air temperature applicability limits between 15 and 50 ºC",
+    );
+  if (kwargs.p_a > 4.5 || kwargs.p_a < 0.5)
+    warnings.push(
+      "ISO 7933:2023 p_a applicability limits between 0.5 and 4.5 kPa",
+    );
+  if (kwargs.tr > 60 || kwargs.tr < 0)
+    warnings.push("ISO 7933:2023 tr applicability limits between 0 and 60 ºC");
+  if (kwargs.v > 3 || kwargs.v < 0)
+    warnings.push(
+      "ISO 7933:2023 air speed applicability limits between 0 and 3 m/s",
+    );
+  if (kwargs.met > 450 || kwargs.met < 100)
+    warnings.push(
+      "ISO 7933:2023 met applicability limits between 100 and 450 met",
+    );
+  if (kwargs.clo > 1 || kwargs.clo < 0.1)
+    warnings.push(
+      "ISO 7933:2023 clo applicability limits between 0.1 and 1 clo",
     );
   return warnings;
 }

--- a/tests/models/phs.test.js
+++ b/tests/models/phs.test.js
@@ -274,4 +274,18 @@ describe("phs scalar tests — inputs outside ISO 7933 applicability limits retu
       expect(Number.isFinite(result[key])).toBe(true),
     );
   });
+
+  test("returns all NaN when p_a < 0.5 kPa with model 7933-2023 (2023 lower limit)", () => {
+    // tdb=20, rh=5 → p_a ≈ 0.12 kPa, valid for 2004 (≥ 0) but invalid for 2023 (< 0.5)
+    const result = phs(20, 20, 0.3, 5, 2.5, 0.5, "standing", 0, "7933-2023");
+    NAN_RESULT_KEYS.forEach((key) => expect(result[key]).toBeNaN());
+  });
+
+  test("returns finite results when p_a < 0.5 kPa with model 7933-2004 (2004 lower limit is 0)", () => {
+    // same input, 2004 accepts p_a ≥ 0
+    const result = phs(20, 20, 0.3, 5, 2.5, 0.5, "standing", 0, "7933-2004");
+    NAN_RESULT_KEYS.forEach((key) =>
+      expect(Number.isFinite(result[key])).toBe(true),
+    );
+  });
 });

--- a/tests/utilities/utilities.test.js
+++ b/tests/utilities/utilities.test.js
@@ -508,14 +508,19 @@ describe("validateInputs", () => {
 // check_standard_compliance ISO7933
 // ---------------------------------------------------------------------------
 describe("check_standard_compliance ISO7933", () => {
-  const base = { tdb: 40, tr: 40, v: 0.3, rh: 33.85, met: 272, clo: 0.5 };
+  // tdb=40, rh=33.85 → p_a ≈ 2.5 kPa (valid for both 2004 and 2023)
+  const base = { tdb: 40, tr: 40, v: 0.3, p_a: 2.5, met: 272, clo: 0.5 };
 
-  test("returns no warnings for valid inputs", () => {
-    expect(check_standard_compliance("ISO7933", base)).toHaveLength(0);
+  test("returns no warnings for valid inputs (2004)", () => {
+    expect(check_standard_compliance("7933-2004", base)).toHaveLength(0);
+  });
+
+  test("returns no warnings for valid inputs (2023)", () => {
+    expect(check_standard_compliance("7933-2023", base)).toHaveLength(0);
   });
 
   test("warns when tr < 0 (fixed: was checking tr - tdb)", () => {
-    const warnings = check_standard_compliance("ISO7933", {
+    const warnings = check_standard_compliance("7933-2004", {
       ...base,
       tr: -5,
     });
@@ -524,7 +529,7 @@ describe("check_standard_compliance ISO7933", () => {
   });
 
   test("warns when tr > 60 (fixed: was checking tr - tdb)", () => {
-    const warnings = check_standard_compliance("ISO7933", {
+    const warnings = check_standard_compliance("7933-2004", {
       ...base,
       tr: 65,
     });
@@ -534,21 +539,34 @@ describe("check_standard_compliance ISO7933", () => {
 
   test("does not warn when tr < tdb but tr is within [0, 60]", () => {
     // tr=20 < tdb=40, old buggy check (tr-tdb < 0) would have warned
-    const warnings = check_standard_compliance("ISO7933", {
+    const warnings = check_standard_compliance("7933-2004", {
       ...base,
       tr: 20,
     });
     expect(warnings).toHaveLength(0);
   });
 
-  test("warns when p_a > 4.5 kPa (fixed: was comparing kPa against %)", () => {
-    // tdb=40, rh=90 → p_a ≈ 6.6 kPa > 4.5
-    const warnings = check_standard_compliance("ISO7933", {
+  test("warns when p_a > 4.5 kPa", () => {
+    const warnings = check_standard_compliance("7933-2004", {
       ...base,
-      rh: 90,
+      p_a: 6.6,
     });
     expect(warnings.length).toBeGreaterThan(0);
     expect(warnings[0]).toMatch(/p_a/i);
+  });
+
+  test("warns when p_a < 0.5 kPa for 2023 but not for 2004", () => {
+    const warnings2004 = check_standard_compliance("7933-2004", {
+      ...base,
+      p_a: 0.2,
+    });
+    const warnings2023 = check_standard_compliance("7933-2023", {
+      ...base,
+      p_a: 0.2,
+    });
+    expect(warnings2004).toHaveLength(0);
+    expect(warnings2023.length).toBeGreaterThan(0);
+    expect(warnings2023[0]).toMatch(/p_a/i);
   });
 });
 

--- a/tests/utilities/utilities.test.js
+++ b/tests/utilities/utilities.test.js
@@ -504,73 +504,59 @@ describe("validateInputs", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// check_standard_compliance ISO7933
-// ---------------------------------------------------------------------------
-describe("check_standard_compliance ISO7933", () => {
-  // tdb=40, rh=33.85 → p_a ≈ 2.5 kPa (valid for both 2004 and 2023)
-  const base = { tdb: 40, tr: 40, v: 0.3, p_a: 2.5, met: 272, clo: 0.5 };
-
-  test("returns no warnings for valid inputs (2004)", () => {
-    expect(check_standard_compliance("7933-2004", base)).toHaveLength(0);
-  });
-
-  test("returns no warnings for valid inputs (2023)", () => {
-    expect(check_standard_compliance("7933-2023", base)).toHaveLength(0);
-  });
-
-  test("warns when tr < 0 (fixed: was checking tr - tdb)", () => {
-    const warnings = check_standard_compliance("7933-2004", {
-      ...base,
-      tr: -5,
-    });
-    expect(warnings.length).toBeGreaterThan(0);
-    expect(warnings[0]).toMatch(/tr/i);
-  });
-
-  test("warns when tr > 60 (fixed: was checking tr - tdb)", () => {
-    const warnings = check_standard_compliance("7933-2004", {
-      ...base,
-      tr: 65,
-    });
-    expect(warnings.length).toBeGreaterThan(0);
-    expect(warnings[0]).toMatch(/tr/i);
-  });
-
-  test("does not warn when tr < tdb but tr is within [0, 60]", () => {
-    // tr=20 < tdb=40, old buggy check (tr-tdb < 0) would have warned
-    const warnings = check_standard_compliance("7933-2004", {
-      ...base,
-      tr: 20,
-    });
-    expect(warnings).toHaveLength(0);
-  });
-
-  test("warns when p_a > 4.5 kPa", () => {
-    const warnings = check_standard_compliance("7933-2004", {
-      ...base,
-      p_a: 6.6,
-    });
-    expect(warnings.length).toBeGreaterThan(0);
-    expect(warnings[0]).toMatch(/p_a/i);
-  });
-
-  test("warns when p_a < 0.5 kPa for 2023 but not for 2004", () => {
-    const warnings2004 = check_standard_compliance("7933-2004", {
-      ...base,
-      p_a: 0.2,
-    });
-    const warnings2023 = check_standard_compliance("7933-2023", {
-      ...base,
-      p_a: 0.2,
-    });
-    expect(warnings2004).toHaveLength(0);
-    expect(warnings2023.length).toBeGreaterThan(0);
-    expect(warnings2023[0]).toMatch(/p_a/i);
-  });
-});
-
 describe("check_standard_compliance", () => {
+  // ---------------------------------------------------------------------------
+  // ISO 7933 (2004 and 2023)
+  // ---------------------------------------------------------------------------
+  describe("ISO 7933 compliance", () => {
+    // tdb=40, tr=40, v=0.3, p_a=2.5 kPa, met=272, clo=0.5 — valid for both standards
+    const base = { tdb: 40, tr: 40, v: 0.3, p_a: 2.5, met: 272, clo: 0.5 };
+
+    test("returns no warnings for valid inputs (2004)", () => {
+      expect(check_standard_compliance("7933-2004", base)).toHaveLength(0);
+    });
+
+    test("returns no warnings for valid inputs (2023)", () => {
+      expect(check_standard_compliance("7933-2023", base)).toHaveLength(0);
+    });
+
+    // Shared boundary conditions — limits are identical for both standards,
+    // so testing with one model is sufficient.
+    it.each([
+      ["tdb < 15 ºC", { tdb: 10 }],
+      ["tdb > 50 ºC", { tdb: 55 }],
+      ["tr < 0 ºC (fixed: was checking tr - tdb)", { tr: -5 }],
+      ["tr > 60 ºC (fixed: was checking tr - tdb)", { tr: 65 }],
+      ["v > 3 m/s", { v: 4 }],
+      ["met < 100 W/m²", { met: 50 }],
+      ["met > 450 W/m²", { met: 500 }],
+      ["clo < 0.1", { clo: 0.05 }],
+      ["clo > 1", { clo: 1.5 }],
+      ["p_a > 4.5 kPa", { p_a: 6.6 }],
+    ])("warns when %s", (_, override) => {
+      const warnings = check_standard_compliance("7933-2004", {
+        ...base,
+        ...override,
+      });
+      expect(warnings.length).toBeGreaterThan(0);
+    });
+
+    test("does not warn when tr < tdb but tr is within [0, 60]", () => {
+      // tr=20 < tdb=40; old buggy check (tr-tdb < 0) would have warned
+      expect(
+        check_standard_compliance("7933-2004", { ...base, tr: 20 }),
+      ).toHaveLength(0);
+    });
+
+    test("warns when p_a < 0.5 kPa for 2023 but not for 2004 (diverging lower bound)", () => {
+      // 2004 lower limit is 0 kPa; 2023 lower limit is 0.5 kPa
+      const input = { ...base, p_a: 0.2 };
+      expect(check_standard_compliance("7933-2004", input)).toHaveLength(0);
+      const warnings2023 = check_standard_compliance("7933-2023", input);
+      expect(warnings2023.length).toBeGreaterThan(0);
+      expect(warnings2023[0]).toMatch(/p_a/i);
+    });
+  });
   describe("ASHRAE airspeed_control branch", () => {
     it("flags v > 0.8 with low clo and met when occupant has no airspeed control", () => {
       const warnings = check_standard_compliance("ASHRAE", {


### PR DESCRIPTION
## What this PR does
#### **Logic fix**
- Split `_iso7933_compliance` into two model-aware functions: `_iso7933_2004_compliance` and `_iso7933_2023_compliance`, mirroring the structure in pythermalcomfort
- Move `p_a` calculation before the compliance check in `phs.js` so the pre-computed value is passed directly instead of being recomputed inside the compliance function
- Apply the correct standard limits for each model (ISO 7933:2023 requires `p_a >= 0.5 kPa`; ISO 7933:2004 uses `p_a >= 0`)

#### **Tests**
- Add tests to `phs.test.js` asserting that the same low-`p_a` input is rejected under 2023 but accepted under 2004
- Update `utilities.test.js` to test `check_standard_compliance` against `"7933-2004"` / `"7933-2023"` directly (replacing the old `"ISO7933"` key), and pass `p_a` as a pre-computed value instead of `rh`

## Why this change is needed

`_iso7933_compliance` previously always enforced ISO 7933:2004 rules regardless of the `model` parameter — it recomputed `p_a` using the 2004 `p_sat()`-based formula and applied a lower `p_a` limit of `0 kPa` even when `model="7933-2023"`, producing incorrect compliance results for the 2023 standard. 

See issue #172 

## How I tested it

- [x] `npm test` — 69 suites, 2258 tests passed, no regression found.

## Notes for reviewers

- The `p_a` pre-computation in `phs.js` is a prerequisite for correctly dispatching to the two compliance functions — the two changes are coupled.

Closes #172