### PR TITLE
Add wind_chill_temperature model

### DIFF
--- a/docs_theme/changelog.md
+++ b/docs_theme/changelog.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented in this file.
 
+## 1.4.0
+
+- Added `wind_chill_temperature(tdb, v)`, which returns the Wind Chill Temperature in °C using the North American formula adopted by the US National Weather Service and Environment Canada. Mirrors `pythermalcomfort` 3.9.3 `wind_chill_temperature`. Wind speed `v` is in km/h, which differs from the existing `wc()` Wind Chill Index that uses m/s. Returns `{ wct }`.
+
 ## 1.3.1 (2026-05-06)
 
 - `heat_index` now returns `{ hi: NaN }` by default when `tdb < 27 °C`, matching `pythermalcomfort` 3.9.3 `heat_index_rothfusz`. IP mode uses the equivalent threshold, `tdb < 80.6 °F`, so the same physical temperature is accepted or rejected regardless of unit system. This is a breaking change compared with previous versions; callers needing the previous behaviour should pass `{ limit_inputs: false }`.

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -7,6 +7,7 @@ import { discomfort_index } from "./discomfort_index.js";
 import { two_nodes } from "./two_nodes.js";
 import { set_tmp } from "./set_tmp.js";
 import { wc } from "./wc.js";
+import { wind_chill_temperature } from "./wind_chill_temperature.js";
 import { adaptive_en } from "./adaptive_en.js";
 import { at } from "./at.js";
 import { pmv_ppd } from "./pmv_ppd.js";
@@ -60,6 +61,7 @@ export {
   vertical_tmp_grad_ppd,
   wbgt,
   wc,
+  wind_chill_temperature,
 };
 
 export default {
@@ -90,5 +92,6 @@ export default {
   vertical_tmp_grad_ppd,
   wbgt,
   wc,
+  wind_chill_temperature,
   JOS3,
 };

--- a/src/models/wind_chill_temperature.js
+++ b/src/models/wind_chill_temperature.js
@@ -19,10 +19,7 @@ import { round, validateInputs } from "../utilities/utilities.js";
  *
  * @param {number} tdb - dry-bulb air temperature, [°C]
  * @param {number} v - wind speed 10 m above ground level, [km/h]
- * @param {object} [kwargs] (Optional) Other parameters.
- * @param {boolean} [kwargs.round_output=true] - if true, rounds the
- *   returned value to one decimal place; if false, returns the unrounded
- *   value.
+ * @param {boolean} [round_output=true] - if true, rounds the returned value to one decimal place; if false, returns the unrounded value.
  * @returns {{wct: number}} wind chill temperature, [°C]
  */
 const WCT_SCHEMA = {
@@ -31,10 +28,8 @@ const WCT_SCHEMA = {
   round_output: { type: "boolean", required: false },
 };
 
-export function wind_chill_temperature(tdb, v, kwargs = {}) {
-  const options = { round_output: true, ...kwargs };
-
-  validateInputs({ tdb, v, round_output: options.round_output }, WCT_SCHEMA);
+export function wind_chill_temperature(tdb, v, round_output = true) {
+  validateInputs({ tdb, v, round_output }, WCT_SCHEMA);
 
   let wct =
     13.12 +
@@ -42,7 +37,7 @@ export function wind_chill_temperature(tdb, v, kwargs = {}) {
     11.37 * Math.pow(v, 0.16) +
     0.3965 * tdb * Math.pow(v, 0.16);
 
-  if (options.round_output) {
+  if (round_output) {
     wct = round(wct, 1);
   }
   return { wct };

--- a/src/models/wind_chill_temperature.js
+++ b/src/models/wind_chill_temperature.js
@@ -1,0 +1,49 @@
+import { round, validateInputs } from "../utilities/utilities.js";
+
+/**
+ * Calculates the Wind Chill Temperature (WCT) using the North American
+ * formula adopted by the US National Weather Service and Environment
+ * Canada in 2001 {@link https://en.wikipedia.org/wiki/Wind_chill#North_American_and_United_Kingdom_wind_chill_index}.
+ *
+ * WCT estimates the equivalent perceived air temperature on exposed skin
+ * given dry-bulb air temperature and 10 m wind speed. It is reported in
+ * the same unit as `tdb` (°C). The formula is empirical and is intended
+ * for cold-weather conditions; outside that range it still evaluates but
+ * carries no physical interpretation. Following `pythermalcomfort`, this
+ * implementation does not gate inputs against an applicability range; the
+ * formula is computed for any finite input.
+ *
+ * @public
+ * @memberof models
+ * @docname Wind chill temperature
+ *
+ * @param {number} tdb - dry-bulb air temperature, [°C]
+ * @param {number} v - wind speed 10 m above ground level, [km/h]
+ * @param {object} [kwargs] (Optional) Other parameters.
+ * @param {boolean} [kwargs.round_output=true] - if true, rounds the
+ *   returned value to one decimal place; if false, returns the unrounded
+ *   value.
+ * @returns {{wct: number}} wind chill temperature, [°C]
+ */
+const WCT_SCHEMA = {
+  tdb: { type: "number" },
+  v: { type: "number" },
+  round_output: { type: "boolean", required: false },
+};
+
+export function wind_chill_temperature(tdb, v, kwargs = {}) {
+  const options = { round_output: true, ...kwargs };
+
+  validateInputs({ tdb, v, round_output: options.round_output }, WCT_SCHEMA);
+
+  let wct =
+    13.12 +
+    0.6215 * tdb -
+    11.37 * Math.pow(v, 0.16) +
+    0.3965 * tdb * Math.pow(v, 0.16);
+
+  if (options.round_output) {
+    wct = round(wct, 1);
+  }
+  return { wct };
+}

--- a/tests/models/wind_chill_temperature.test.js
+++ b/tests/models/wind_chill_temperature.test.js
@@ -28,12 +28,7 @@ describe("test_wind_chill_temperature", () => {
   test.each(testCases)("Test case #%#", (testCase) => {
     const { inputs, outputs: expectedOutput } = testCase;
     const { tdb, v, round_output } = inputs;
-    // Only build a kwargs object when round_output is explicit in the
-    // row, so rows without that key exercise the function's own default
-    // (true). Without this guard, undefined would coerce to skipping
-    // rounding and silently widen the assertion window.
-    const kwargs = round_output !== undefined ? { round_output } : undefined;
-    const modelResult = wind_chill_temperature(tdb, v, kwargs);
+    const modelResult = wind_chill_temperature(tdb, v, round_output);
     validateResult(modelResult, expectedOutput, tolerances, inputs);
   });
 });
@@ -46,18 +41,14 @@ describe("test_wind_chill_temperature", () => {
 // binary value.
 describe("wind_chill_temperature unrounded path", () => {
   test("round_output:false returns the full-precision pythermalcomfort value", () => {
-    const result = wind_chill_temperature(-5, 5.5, { round_output: false });
+    const result = wind_chill_temperature(-5, 5.5, false);
     expect(Math.abs(result.wct - -7.527137645688018)).toBeLessThan(1e-10);
   });
 });
 
-// Passing an empty kwargs object must still apply the documented
-// round_output=true default. Without the explicit merge in the function
-// body, kwargs.round_output would be undefined and the branch would
-// silently return an unrounded value.
-describe("wind_chill_temperature kwargs defaults", () => {
-  test("empty kwargs keeps round_output default true", () => {
-    expect(wind_chill_temperature(-5, 5.5, {}).wct).toBe(-7.5);
+describe("wind_chill_temperature round_output default", () => {
+  test("omitting round_output keeps the default true", () => {
+    expect(wind_chill_temperature(-5, 5.5).wct).toBe(-7.5);
   });
 });
 
@@ -70,8 +61,6 @@ describe("wind_chill_temperature input validation", () => {
   });
 
   test("throws TypeError if round_output is not a boolean", () => {
-    expect(() =>
-      wind_chill_temperature(0, 5, { round_output: "true" }),
-    ).toThrow(TypeError);
+    expect(() => wind_chill_temperature(0, 5, "true")).toThrow(TypeError);
   });
 });

--- a/tests/models/wind_chill_temperature.test.js
+++ b/tests/models/wind_chill_temperature.test.js
@@ -1,0 +1,77 @@
+// Reference values match pythermalcomfort 3.9.3 and are also proposed in
+// FedericoTartarini/validation-data-comfort-models#10. Once that PR
+// merges these rows should move to ts_wind_chill_temperature.json and the
+// suite should switch to loadTestData(testDataUrls.windChillTemperature).
+
+import { describe, expect, test } from "@jest/globals";
+import { wind_chill_temperature } from "../../src/models/wind_chill_temperature.js";
+import { validateResult } from "./testUtils";
+
+const tolerances = { wct: 0.1 };
+
+const testCases = [
+  { inputs: { tdb: -40, v: 30 }, outputs: { wct: -58.7 } },
+  { inputs: { tdb: -20, v: 5 }, outputs: { wct: -24.3 } },
+  { inputs: { tdb: -20, v: 15 }, outputs: { wct: -29.1 } },
+  { inputs: { tdb: -20, v: 60 }, outputs: { wct: -36.5 } },
+  { inputs: { tdb: -10, v: 10 }, outputs: { wct: -15.3 } },
+  { inputs: { tdb: -5, v: 5.5 }, outputs: { wct: -7.5 } },
+  {
+    inputs: { tdb: -5, v: 5.5, round_output: false },
+    outputs: { wct: -7.527 },
+  },
+  { inputs: { tdb: 0, v: 0.1 }, outputs: { wct: 5.3 } },
+  { inputs: { tdb: 0, v: 1.5 }, outputs: { wct: 1.0 } },
+];
+
+describe("test_wind_chill_temperature", () => {
+  test.each(testCases)("Test case #%#", (testCase) => {
+    const { inputs, outputs: expectedOutput } = testCase;
+    const { tdb, v, round_output } = inputs;
+    // Only build a kwargs object when round_output is explicit in the
+    // row, so rows without that key exercise the function's own default
+    // (true). Without this guard, undefined would coerce to skipping
+    // rounding and silently widen the assertion window.
+    const kwargs = round_output !== undefined ? { round_output } : undefined;
+    const modelResult = wind_chill_temperature(tdb, v, kwargs);
+    validateResult(modelResult, expectedOutput, tolerances, inputs);
+  });
+});
+
+// The row-level tolerance is 0.1, which is looser than the difference
+// between the rounded and unrounded outputs of the boundary case
+// (|-7.5 - -7.527| = 0.027). A buggy implementation that ignored
+// round_output: false would still pass the loop above. This tighter
+// check locks the unrounded path against the pythermalcomfort 3.9.3
+// binary value.
+describe("wind_chill_temperature unrounded path", () => {
+  test("round_output:false returns the full-precision pythermalcomfort value", () => {
+    const result = wind_chill_temperature(-5, 5.5, { round_output: false });
+    expect(Math.abs(result.wct - -7.527137645688018)).toBeLessThan(1e-10);
+  });
+});
+
+// Passing an empty kwargs object must still apply the documented
+// round_output=true default. Without the explicit merge in the function
+// body, kwargs.round_output would be undefined and the branch would
+// silently return an unrounded value.
+describe("wind_chill_temperature kwargs defaults", () => {
+  test("empty kwargs keeps round_output default true", () => {
+    expect(wind_chill_temperature(-5, 5.5, {}).wct).toBe(-7.5);
+  });
+});
+
+describe("wind_chill_temperature input validation", () => {
+  test.each([
+    ["tdb", "0", 5],
+    ["v", 0, "5"],
+  ])("throws TypeError if %s is not a number", (_, ...args) => {
+    expect(() => wind_chill_temperature(...args)).toThrow(TypeError);
+  });
+
+  test("throws TypeError if round_output is not a boolean", () => {
+    expect(() =>
+      wind_chill_temperature(0, 5, { round_output: "true" }),
+    ).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
Adds `wind_chill_temperature(tdb, v)`, which returns the Wind Chill Temperature in °C using the North American formula adopted by the US National Weather Service and Environment Canada. Mirrors `pythermalcomfort` 3.9.3 `wind_chill_temperature`. Motivated by comfort-tool, which currently computes WCT manually because jsthermalcomfort only exposes `wc()` (Wind Chill Index in W/m², ASHRAE / Siple-Passel), a different quantity.

The signature is `wind_chill_temperature(tdb, v, { round_output = true })`, returning `{ wct }`. `tdb` is in °C and `v` is in km/h, matching `pythermalcomfort`; this differs from the existing `wc()` function, which uses m/s. `round_output` defaults to `true`, rounding to one decimal place.

The NWS standard applicability is `tdb ≤ 10 °C` and `v ≥ 4.8 km/h`. Following `pythermalcomfort`, this implementation does not gate inputs; the formula is evaluated for any finite input.

Shared validation data has been proposed in FedericoTartarini/validation-data-comfort-models#10. Until that is merged this PR keeps the WCT reference rows local to avoid depending on an unmerged fixture branch in CI. The Jest suite also includes a tight binary check (`|wct - -7.527137645688018| < 1e-10`) on the unrounded path since the row tolerance (0.1) is too loose to lock that path alone.