### PR TITLE
feat: export check_standard_compliance as a named export

### DIFF
--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -8,6 +8,7 @@ import {
   met_typical_tasks,
   clo_typical_ensembles,
   clo_individual_garments,
+  check_standard_compliance,
 } from "./utilities.js";
 
 /**
@@ -25,6 +26,7 @@ export {
   met_typical_tasks,
   clo_typical_ensembles,
   clo_individual_garments,
+  check_standard_compliance,
 };
 
 export default {
@@ -37,6 +39,7 @@ export default {
   met_typical_tasks,
   clo_typical_ensembles,
   clo_individual_garments,
+  check_standard_compliance,
 };
 
 /**

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -158,6 +158,12 @@ describe("NPM Package", () => {
     );
   });
 
+  it("should have utilities.check_standard_compliance", () => {
+    expect(jsthermalcomfort.utilities).toHaveProperty(
+      "check_standard_compliance",
+    );
+  });
+
   it("should have psychrometrics.p_sat", () => {
     expect(jsthermalcomfort.psychrometrics).toHaveProperty("p_sat");
   });


### PR DESCRIPTION
This PR simply adds check_standard_compliance as a named export, and adds a unit test for the export, in order to avoid deep path importing in comfort-tool.