### PR TITLE
Add optional round_output to adaptive_ashrae and adaptive_en

### DIFF
--- a/docs_theme/changelog.md
+++ b/docs_theme/changelog.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 ## 1.4.0
 
 - Added `wind_chill_temperature(tdb, v)`, which returns the Wind Chill Temperature in °C using the North American formula adopted by the US National Weather Service and Environment Canada. Mirrors `pythermalcomfort` 3.9.3 `wind_chill_temperature`. Wind speed `v` is in km/h, which differs from the existing `wc()` Wind Chill Index that uses m/s. Returns `{ wct }`.
+- Added optional `round_output` parameter to `adaptive_ashrae(tdb, tr, t_running_mean, v, units, limit_inputs, round_output)` and `adaptive_en(tdb, tr, t_running_mean, v, units, limit_inputs, round_output)`. Defaults to `true`, preserving current behaviour. Passing `false` returns full-precision comfort temperatures and bounds, useful when chaining downstream calculations or when the caller applies its own formatting. This parameter is a jsthermalcomfort-specific enhancement and is not present in `pythermalcomfort`.
 
 ## 1.3.1 (2026-05-06)
 

--- a/src/models/adaptive_ashrae.js
+++ b/src/models/adaptive_ashrae.js
@@ -45,6 +45,7 @@ import { get_ce } from "./adaptive_en.js";
  * @param {boolean} limit_inputs - By default, if the inputs are outsude the standard applicability limits the
  * function returns nan. If False returns pmv and ppd values even if input values are
  * outside the applicability limits of the model.
+ * @param {boolean} [round_output=true] - if true, rounds `t_cmf` to one decimal place in SI before bounds are derived; if false, returns the unrounded values. Under `units = 'IP'` the rounded SI value is then converted to °F, so IP outputs carry the additional decimals from the °C-to-°F conversion.
  *
  * @returns {AdaptiveAshraeResult} set containing results for the model
  *
@@ -88,6 +89,7 @@ const ADAPTIVE_ASHRAE_SCHEMA = {
   v: { type: "number" },
   units: { enum: ["SI", "IP"] },
   limit_inputs: { type: "boolean" },
+  round_output: { type: "boolean", required: false },
 };
 
 export function adaptive_ashrae(
@@ -97,9 +99,18 @@ export function adaptive_ashrae(
   v,
   units = "SI",
   limit_inputs = true,
+  round_output = true,
 ) {
   validateInputs(
-    { tdb, tr, t_running_mean, v, units: units.toUpperCase(), limit_inputs },
+    {
+      tdb,
+      tr,
+      t_running_mean,
+      v,
+      units: units.toUpperCase(),
+      limit_inputs,
+      round_output,
+    },
     ADAPTIVE_ASHRAE_SCHEMA,
   );
 
@@ -129,7 +140,9 @@ export function adaptive_ashrae(
     if (warnings.length > 0 || !trm_valid) t_cmf = NaN;
   }
 
-  t_cmf = round(t_cmf, 1);
+  if (round_output) {
+    t_cmf = round(t_cmf, 1);
+  }
 
   let tmp_cmf_80_low = t_cmf - 3.5;
   let tmp_cmf_90_low = t_cmf - 2.5;

--- a/src/models/adaptive_en.js
+++ b/src/models/adaptive_en.js
@@ -48,6 +48,7 @@ import {
  * @param {boolean} [limit_inputs=true] - By default, if the inputs are outsude the standard applicability limits the
  * function returns nan. If False returns pmv and ppd values even if input values are
  * outside the applicability limits of the model.
+ * @param {boolean} [round_output=true] - if true, rounds the returned comfort temperature and bounds to one decimal place in the output unit (rounding is applied after any IP unit conversion); if false, returns the unrounded values.
  *
  * @returns {AdaptiveEnResult} result set
  *
@@ -75,6 +76,7 @@ const ADAPTIVE_EN_SCHEMA = {
   v: { type: "number" },
   units: { enum: ["SI", "IP"] },
   limit_inputs: { type: "boolean" },
+  round_output: { type: "boolean", required: false },
 };
 
 export function adaptive_en(
@@ -84,9 +86,18 @@ export function adaptive_en(
   v,
   units = "SI",
   limit_inputs = true,
+  round_output = true,
 ) {
   validateInputs(
-    { tdb, tr, t_running_mean, v, units: units.toUpperCase(), limit_inputs },
+    {
+      tdb,
+      tr,
+      t_running_mean,
+      v,
+      units: units.toUpperCase(),
+      limit_inputs,
+      round_output,
+    },
     ADAPTIVE_EN_SCHEMA,
   );
 
@@ -152,17 +163,27 @@ export function adaptive_en(
     ));
   }
 
+  if (round_output) {
+    t_cmf = round(t_cmf, 1);
+    t_cmf_i_lower = round(t_cmf_i_lower, 1);
+    t_cmf_ii_lower = round(t_cmf_ii_lower, 1);
+    t_cmf_iii_lower = round(t_cmf_iii_lower, 1);
+    t_cmf_i_upper = round(t_cmf_i_upper, 1);
+    t_cmf_ii_upper = round(t_cmf_ii_upper, 1);
+    t_cmf_iii_upper = round(t_cmf_iii_upper, 1);
+  }
+
   return {
-    tmp_cmf: round(t_cmf, 1),
+    tmp_cmf: t_cmf,
     acceptability_cat_i: acceptability_i,
     acceptability_cat_ii: acceptability_ii,
     acceptability_cat_iii: acceptability_iii,
-    tmp_cmf_cat_i_up: round(t_cmf_i_upper, 1),
-    tmp_cmf_cat_ii_up: round(t_cmf_ii_upper, 1),
-    tmp_cmf_cat_iii_up: round(t_cmf_iii_upper, 1),
-    tmp_cmf_cat_i_low: round(t_cmf_i_lower, 1),
-    tmp_cmf_cat_ii_low: round(t_cmf_ii_lower, 1),
-    tmp_cmf_cat_iii_low: round(t_cmf_iii_lower, 1),
+    tmp_cmf_cat_i_up: t_cmf_i_upper,
+    tmp_cmf_cat_ii_up: t_cmf_ii_upper,
+    tmp_cmf_cat_iii_up: t_cmf_iii_upper,
+    tmp_cmf_cat_i_low: t_cmf_i_lower,
+    tmp_cmf_cat_ii_low: t_cmf_ii_lower,
+    tmp_cmf_cat_iii_low: t_cmf_iii_lower,
   };
 }
 /**

--- a/tests/models/adaptive_ashrae.test.js
+++ b/tests/models/adaptive_ashrae.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { adaptive_ashrae } from "../../src/models/adaptive_ashrae";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils";
@@ -69,6 +69,61 @@ describe("adaptive_ashrae scalar tests (hardcoded)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// round_output unrounded path
+// Reference value is derived analytically from the model equation
+// t_cmf = 0.31 * t_running_mean + 17.8, giving 24.62 at t_running_mean = 22.
+// Default round_output = true yields 24.6.
+//
+// Note: round_output=false propagates unrounded t_cmf into bounds,
+// which can shift acceptability flags at narrow boundary inputs.
+// The test below uses a non-boundary input to verify the typical case.
+// ---------------------------------------------------------------------------
+describe("adaptive_ashrae unrounded path", () => {
+  test("round_output:false returns the unrounded comfort temperature and bounds", () => {
+    const rounded = adaptive_ashrae(25, 25, 22, 0.1);
+    const unrounded = adaptive_ashrae(25, 25, 22, 0.1, "SI", true, false);
+    expect(rounded.tmp_cmf).toBe(24.6);
+    expect(Math.abs(unrounded.tmp_cmf - 24.62)).toBeLessThan(1e-10);
+    expect(unrounded.tmp_cmf).not.toBe(rounded.tmp_cmf);
+    // tmp_cmf_80_low = t_cmf - 3.5: 24.62 - 3.5 = 21.12 unrounded; 21.1 rounded.
+    expect(rounded.tmp_cmf_80_low).toBe(21.1);
+    expect(Math.abs(unrounded.tmp_cmf_80_low - 21.12)).toBeLessThan(1e-10);
+    expect(unrounded.tmp_cmf_80_low).not.toBe(rounded.tmp_cmf_80_low);
+  });
+});
+
+describe("adaptive_ashrae round_output default", () => {
+  test("omitting round_output keeps the default true", () => {
+    expect(adaptive_ashrae(25, 25, 22, 0.1).tmp_cmf).toBe(24.6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cooling-effect acceptability boundary
+// Locks the cooling-effect gate (get_ce) inside adaptive_ashrae. At
+// v >= 0.6 and to >= 25, ce = 1.2 widens the 90% upper bound from
+// t_cmf + 2.5 to t_cmf + 2.5 + 1.2, which flips acceptability_90 from
+// false (no cooling effect, v = 0.1) to true (cooling effect, v = 0.6)
+// at (tdb=tr=28, t_running_mean=22). Any future change that drops the
+// gate fails this test.
+// ---------------------------------------------------------------------------
+describe("adaptive_ashrae cooling-effect boundary", () => {
+  test("v=0.6 widens 90% acceptability at to=28; v=0.1 does not", () => {
+    const wide = adaptive_ashrae(28, 28, 22, 0.6);
+    const narrow = adaptive_ashrae(28, 28, 22, 0.1);
+    expect(wide.acceptability_90).toBe(true);
+    expect(narrow.acceptability_90).toBe(false);
+  });
+
+  test("round_output:false acceptability matches round_output:true at non-boundary input", () => {
+    const rounded = adaptive_ashrae(28, 28, 22, 0.6);
+    const unrounded = adaptive_ashrae(28, 28, 22, 0.6, "SI", true, false);
+    expect(unrounded.acceptability_80).toBe(rounded.acceptability_80);
+    expect(unrounded.acceptability_90).toBe(rounded.acceptability_90);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Input validation tests
 // ---------------------------------------------------------------------------
 describe("adaptive_ashrae input validation", () => {
@@ -87,6 +142,12 @@ describe("adaptive_ashrae input validation", () => {
 
   test("throws TypeError if limit_inputs is not a boolean", () => {
     expect(() => adaptive_ashrae(25, 25, 20, 0.1, "SI", "true")).toThrow(
+      TypeError,
+    );
+  });
+
+  test("throws TypeError if round_output is not a boolean", () => {
+    expect(() => adaptive_ashrae(25, 25, 20, 0.1, "SI", true, "true")).toThrow(
       TypeError,
     );
   });

--- a/tests/models/adaptive_en.test.js
+++ b/tests/models/adaptive_en.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "@jest/globals";
+import { describe, expect, test } from "@jest/globals";
 import { adaptive_en } from "../../src/models/adaptive_en";
 import { testDataUrls } from "./comftest";
 import { loadTestData, validateResult } from "./testUtils"; // use the utils
@@ -74,6 +74,58 @@ describe("adaptive_en scalar tests (hardcoded)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// round_output unrounded path
+// Reference value is derived analytically from the model equation
+// t_cmf = 0.33 * t_running_mean + 18.8, giving 26.06 at t_running_mean = 22.
+// Default round_output = true yields 26.1.
+// ---------------------------------------------------------------------------
+describe("adaptive_en unrounded path", () => {
+  test("round_output:false returns the unrounded comfort temperature and bounds", () => {
+    const rounded = adaptive_en(25, 25, 22, 0.1);
+    const unrounded = adaptive_en(25, 25, 22, 0.1, "SI", true, false);
+    expect(rounded.tmp_cmf).toBe(26.1);
+    expect(Math.abs(unrounded.tmp_cmf - 26.06)).toBeLessThan(1e-10);
+    expect(unrounded.tmp_cmf).not.toBe(rounded.tmp_cmf);
+    // tmp_cmf_cat_ii_low = t_cmf - 4.0: 26.06 - 4.0 = 22.06 unrounded; 22.1 rounded.
+    expect(rounded.tmp_cmf_cat_ii_low).toBe(22.1);
+    expect(Math.abs(unrounded.tmp_cmf_cat_ii_low - 22.06)).toBeLessThan(1e-10);
+    expect(unrounded.tmp_cmf_cat_ii_low).not.toBe(rounded.tmp_cmf_cat_ii_low);
+  });
+});
+
+describe("adaptive_en round_output default", () => {
+  test("omitting round_output keeps the default true", () => {
+    expect(adaptive_en(25, 25, 22, 0.1).tmp_cmf).toBe(26.1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cooling-effect acceptability boundary
+// Locks the cooling-effect gate (get_ce) inside adaptive_en. At
+// v >= 0.6 and to >= 25, ce = 1.2 widens the category I upper bound
+// from t_cmf + 2.0 to t_cmf + 2.0 + 1.2, which flips
+// acceptability_cat_i from false (no cooling effect, v = 0.1) to true
+// (cooling effect, v = 0.6) at (tdb=tr=29, t_running_mean=22). Any
+// future change that drops the gate fails this test.
+// ---------------------------------------------------------------------------
+describe("adaptive_en cooling-effect boundary", () => {
+  test("v=0.6 widens cat_i acceptability at to=29; v=0.1 does not", () => {
+    const wide = adaptive_en(29, 29, 22, 0.6);
+    const narrow = adaptive_en(29, 29, 22, 0.1);
+    expect(wide.acceptability_cat_i).toBe(true);
+    expect(narrow.acceptability_cat_i).toBe(false);
+  });
+
+  test("round_output:false preserves cooling-effect acceptability flags", () => {
+    const rounded = adaptive_en(29, 29, 22, 0.6);
+    const unrounded = adaptive_en(29, 29, 22, 0.6, "SI", true, false);
+    expect(unrounded.acceptability_cat_i).toBe(rounded.acceptability_cat_i);
+    expect(unrounded.acceptability_cat_ii).toBe(rounded.acceptability_cat_ii);
+    expect(unrounded.acceptability_cat_iii).toBe(rounded.acceptability_cat_iii);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Input validation tests
 // ---------------------------------------------------------------------------
 describe("adaptive_en input validation", () => {
@@ -92,5 +144,11 @@ describe("adaptive_en input validation", () => {
 
   test("throws TypeError if limit_inputs is not a boolean", () => {
     expect(() => adaptive_en(25, 25, 20, 0.1, "SI", "true")).toThrow(TypeError);
+  });
+
+  test("throws TypeError if round_output is not a boolean", () => {
+    expect(() => adaptive_en(25, 25, 20, 0.1, "SI", true, "true")).toThrow(
+      TypeError,
+    );
   });
 });


### PR DESCRIPTION
Adds an optional `round_output` parameter (positional, default `true`) to `adaptive_ashrae` and `adaptive_en`. With `round_output: false`, comfort temperatures and bounds are returned at full precision. Default behaviour is unchanged.

For `adaptive_ashrae`, because `t_cmf` is rounded before bounds are derived in current `main`, the unrounded path also propagates into bound derivation and can shift `acceptability_80` / `acceptability_90` at very narrow boundaries (within roughly 0.05 °C). This is intentional. `adaptive_en` doesn't have this propagation; its `t_cmf` is only rounded at the return site.

PR #166 explored a different rounding approach via cooling-effect changes and was closed; this PR keeps the cooling-effect logic unchanged. Paired upstream issue at pythermalcomfort/pythermalcomfort#323. New tests cover unrounded values, default preservation, the cooling-effect boundary, and the non-boolean type check.
